### PR TITLE
Split maps into chunks

### DIFF
--- a/game-logic/Cargo.toml
+++ b/game-logic/Cargo.toml
@@ -8,3 +8,4 @@ description = "Common logic between the server and the frontend"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.3.3"
+fnv = "1.0.7"

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -12,7 +12,7 @@ use crate::{
     task::{GlobalTask, Task, RAW_ORE_SMELT_TIME},
     tile::Tiles,
     transport::find_multipath,
-    AsteroidColoniesGame, Cell, CellState, Crew, ItemType, Transport, Xor128, WIDTH,
+    AsteroidColoniesGame, CellState, Crew, ItemType, Transport, Xor128,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -278,13 +278,13 @@ impl AsteroidColoniesGame {
                         self.buildings.push(Building::new(pos, ty));
                     }
                     ConstructionType::PowerGrid => {
-                        if let Some(cell) = self.tiles.try_get_mut(pos) {
-                            cell.power_grid = true;
+                        if let Some(tile) = self.tiles.try_get_mut(pos) {
+                            tile.power_grid = true;
                         }
                     }
                     ConstructionType::Conveyor(conv) => {
-                        if let Some(cell) = self.tiles.try_get_mut(pos) {
-                            cell.conveyor = conv;
+                        if let Some(tile) = self.tiles.try_get_mut(pos) {
+                            tile.conveyor = conv;
                         }
                     }
                 }

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -247,7 +247,7 @@ impl AsteroidColoniesGame {
                     to_delete.push(i);
                 } else if construction.progress <= 0. {
                     push_outputs(
-                        &self.cells,
+                        &self.tiles,
                         &mut self.transports,
                         construction,
                         &mut self.buildings,
@@ -259,7 +259,7 @@ impl AsteroidColoniesGame {
             } else {
                 pull_inputs(
                     &construction.recipe.ingredients,
-                    &self.cells,
+                    &self.tiles,
                     &mut self.transports,
                     construction.pos,
                     construction.size(),
@@ -278,12 +278,12 @@ impl AsteroidColoniesGame {
                         self.buildings.push(Building::new(pos, ty));
                     }
                     ConstructionType::PowerGrid => {
-                        if let Some(cell) = self.cells.try_get_mut(pos) {
+                        if let Some(cell) = self.tiles.try_get_mut(pos) {
                             cell.power_grid = true;
                         }
                     }
                     ConstructionType::Conveyor(conv) => {
-                        if let Some(cell) = self.cells.try_get_mut(pos) {
+                        if let Some(cell) = self.tiles.try_get_mut(pos) {
                             cell.conveyor = conv;
                         }
                     }

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -247,7 +247,7 @@ impl AsteroidColoniesGame {
                     to_delete.push(i);
                 } else if construction.progress <= 0. {
                     push_outputs(
-                        &&self.cells[..],
+                        &self.cells,
                         &mut self.transports,
                         construction,
                         &mut self.buildings,
@@ -259,7 +259,7 @@ impl AsteroidColoniesGame {
             } else {
                 pull_inputs(
                     &construction.recipe.ingredients,
-                    &&self.cells[..],
+                    &self.cells,
                     &mut self.transports,
                     construction.pos,
                     construction.size(),
@@ -278,10 +278,14 @@ impl AsteroidColoniesGame {
                         self.buildings.push(Building::new(pos, ty));
                     }
                     ConstructionType::PowerGrid => {
-                        self.cells[pos[0] as usize + pos[1] as usize * WIDTH].power_grid = true;
+                        if let Some(cell) = self.cells.try_get_mut(pos) {
+                            cell.power_grid = true;
+                        }
                     }
                     ConstructionType::Conveyor(conv) => {
-                        self.cells[pos[0] as usize + pos[1] as usize * WIDTH].conveyor = conv;
+                        if let Some(cell) = self.cells.try_get_mut(pos) {
+                            cell.conveyor = conv;
+                        }
                     }
                 }
                 to_delete.push(i);

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -6,7 +6,7 @@ use crate::{
     push_pull::{pull_inputs, push_outputs, HasInventory},
     task::{Direction, BUILD_CONVEYOR_TIME, BUILD_POWER_GRID_TIME},
     transport::{expected_deliveries, Transport},
-    Conveyor, Inventory, ItemType, Pos, WIDTH,
+    Conveyor, Inventory, ItemType, Pos,
 };
 
 use super::{hash_map, AsteroidColoniesGame};

--- a/game-logic/src/conveyor.rs
+++ b/game-logic/src/conveyor.rs
@@ -106,7 +106,7 @@ impl AsteroidColoniesGame {
         let mut prev_from = Option::None;
 
         let pos = [ix0, iy0];
-        let cell = &self.cells[pos[0] as usize + pos[1] as usize * WIDTH];
+        let cell = &self.cells[pos];
         if let Some(from) = self
             .conveyor_staged
             .get(&pos)
@@ -145,7 +145,7 @@ impl AsteroidColoniesGame {
 
         // console_log!("conv pos ix0: {ix0}, ix1: {ix1}, xrev: {x_rev}, iy0: {iy0}, iy1: {iy1}, yrev: {y_rev}, {:?}", convs);
         for (pos0, pos1) in convs.iter().zip(convs.iter().skip(1)) {
-            let cell = &self.cells[pos0[0] as usize + pos0[1] as usize * WIDTH];
+            let cell = &self.cells[*pos0];
             let staged = self.conveyor_staged.get(pos0).copied().unwrap_or(None);
             let Some(to) = Direction::from_vec([pos1[0] - pos0[0], pos1[1] - pos0[1]]) else {
                 continue;
@@ -159,7 +159,7 @@ impl AsteroidColoniesGame {
         }
 
         if let Some((pos, prev_from)) = convs.last().zip(prev_from) {
-            let cell = &self.cells[pos[0] as usize + pos[1] as usize * WIDTH];
+            let cell = &self.cells[*pos];
             let staged = self.conveyor_staged.get(pos).copied().unwrap_or(None);
             let to = self
                 .conveyor_staged

--- a/game-logic/src/conveyor.rs
+++ b/game-logic/src/conveyor.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use crate::{
     console_log, construction::Construction, push_pull::TileSampler, task::Direction,
-    AsteroidColoniesGame, Cell, WIDTH,
+    AsteroidColoniesGame, Cell,
 };
 use serde::{Deserialize, Serialize};
 

--- a/game-logic/src/conveyor.rs
+++ b/game-logic/src/conveyor.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, hash::Hash};
 
 use crate::{
     console_log, construction::Construction, push_pull::TileSampler, task::Direction,
@@ -16,6 +16,37 @@ pub enum Conveyor {
     Splitter(Direction),
     /// Assume a splitter merges from the other 3 directions
     Merger(Direction),
+}
+
+impl Hash for Conveyor {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // It's annoying to define hash logic for all cases, but we need to do it
+        // manually to ensure it's compatible among CPU architectures, namely
+        // Wasm32 and x64.
+        match self {
+            Self::None => 0u8.hash(state),
+            Self::One(a, b) => {
+                1u8.hash(state);
+                a.hash(state);
+                b.hash(state);
+            }
+            Self::Two((a, b), (c, d)) => {
+                2u8.hash(state);
+                a.hash(state);
+                b.hash(state);
+                c.hash(state);
+                d.hash(state);
+            }
+            Self::Splitter(a) => {
+                3u8.hash(state);
+                a.hash(state);
+            }
+            Self::Merger(a) => {
+                4u8.hash(state);
+                a.hash(state);
+            }
+        }
+    }
 }
 
 impl Conveyor {

--- a/game-logic/src/conveyor.rs
+++ b/game-logic/src/conveyor.rs
@@ -137,12 +137,12 @@ impl AsteroidColoniesGame {
         let mut prev_from = Option::None;
 
         let pos = [ix0, iy0];
-        let cell = &self.tiles[pos];
+        let tile = &self.tiles[pos];
         if let Some(from) = self
             .conveyor_staged
             .get(&pos)
             .and_then(|c| c.from())
-            .or_else(|| cell.conveyor.from())
+            .or_else(|| tile.conveyor.from())
         {
             console_log!("conv from: {:?}", from);
             prev_from = Some(from);
@@ -160,7 +160,7 @@ impl AsteroidColoniesGame {
             convs.extend((ix0..=ix1).map(|ix| [ix, iy1]));
         }
 
-        let filter_conv = |cell: &Tile, staged, conv| match (cell.conveyor, conv) {
+        let filter_conv = |tile: &Tile, staged, conv| match (tile.conveyor, conv) {
             (One(Left, Right), (Up, Down) | (Down, Up)) => Two((Left, Right), conv),
             (One(Right, Left), (Up, Down) | (Down, Up)) => Two((Right, Left), conv),
             (One(Up, Down), (Left, Right) | (Right, Left)) => Two((Up, Down), conv),
@@ -176,29 +176,29 @@ impl AsteroidColoniesGame {
 
         // console_log!("conv pos ix0: {ix0}, ix1: {ix1}, xrev: {x_rev}, iy0: {iy0}, iy1: {iy1}, yrev: {y_rev}, {:?}", convs);
         for (pos0, pos1) in convs.iter().zip(convs.iter().skip(1)) {
-            let cell = &self.tiles[*pos0];
+            let tile = &self.tiles[*pos0];
             let staged = self.conveyor_staged.get(pos0).copied().unwrap_or(None);
             let Some(to) = Direction::from_vec([pos1[0] - pos0[0], pos1[1] - pos0[1]]) else {
                 continue;
             };
             let from = prev_from.unwrap_or_else(|| to.reverse());
             prev_from = Some(to.reverse());
-            let conv = filter_conv(cell, staged, (from, to));
+            let conv = filter_conv(tile, staged, (from, to));
             console_log!("pos {:?} conv {:?}", pos0, conv);
             // console_log!("conv {:?}: {:?}", pos1, conv);
             self.conveyor_preview.insert(*pos0, conv);
         }
 
         if let Some((pos, prev_from)) = convs.last().zip(prev_from) {
-            let cell = &self.tiles[*pos];
+            let tile = &self.tiles[*pos];
             let staged = self.conveyor_staged.get(pos).copied().unwrap_or(None);
             let to = self
                 .conveyor_staged
                 .get(pos)
                 .and_then(|c| c.to())
-                .or_else(|| cell.conveyor.to())
+                .or_else(|| tile.conveyor.to())
                 .unwrap_or_else(|| prev_from.reverse());
-            let conv = filter_conv(cell, staged, (prev_from, to));
+            let conv = filter_conv(tile, staged, (prev_from, to));
             self.conveyor_preview.insert(*pos, conv);
         }
 
@@ -211,7 +211,7 @@ impl AsteroidColoniesGame {
     pub fn build_splitter(&mut self, ix0: i32, iy0: i32) {
         use {Conveyor::*, Direction::*};
 
-        let filter_conv = |cell: Conveyor, staged| match cell {
+        let filter_conv = |tile: Conveyor, staged| match tile {
             One(from, _) => Splitter(from),
             Two((from1, _), (_, _)) => Splitter(from1),
             _ => match staged {
@@ -222,7 +222,7 @@ impl AsteroidColoniesGame {
         };
 
         let pos0 = [ix0, iy0];
-        let cell = self
+        let tile = self
             .tiles
             .at([ix0, iy0])
             .map(|c| c.conveyor)
@@ -230,21 +230,21 @@ impl AsteroidColoniesGame {
         let staged = self.conveyor_staged.get(&pos0).copied().unwrap_or(None);
 
         self.conveyor_staged
-            .insert([ix0, iy0], filter_conv(cell, staged));
+            .insert([ix0, iy0], filter_conv(tile, staged));
     }
 
     pub fn build_merger(&mut self, ix0: i32, iy0: i32) {
         use {Conveyor::*, Direction::*};
 
         let pos0 = [ix0, iy0];
-        let cell = self
+        let tile = self
             .tiles
             .at([ix0, iy0])
             .map(|c| c.conveyor)
             .unwrap_or(None);
         let staged = self.conveyor_staged.get(&pos0).copied().unwrap_or(None);
 
-        let filtered = match cell {
+        let filtered = match tile {
             One(_, to) => Merger(to),
             Two((_, to1), _) => Merger(to1),
             _ => match staged {

--- a/game-logic/src/conveyor.rs
+++ b/game-logic/src/conveyor.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, hash::Hash};
 
 use crate::{
     console_log, construction::Construction, push_pull::TileSampler, task::Direction,
-    AsteroidColoniesGame, Cell,
+    AsteroidColoniesGame, Tile,
 };
 use serde::{Deserialize, Serialize};
 
@@ -137,7 +137,7 @@ impl AsteroidColoniesGame {
         let mut prev_from = Option::None;
 
         let pos = [ix0, iy0];
-        let cell = &self.cells[pos];
+        let cell = &self.tiles[pos];
         if let Some(from) = self
             .conveyor_staged
             .get(&pos)
@@ -160,7 +160,7 @@ impl AsteroidColoniesGame {
             convs.extend((ix0..=ix1).map(|ix| [ix, iy1]));
         }
 
-        let filter_conv = |cell: &Cell, staged, conv| match (cell.conveyor, conv) {
+        let filter_conv = |cell: &Tile, staged, conv| match (cell.conveyor, conv) {
             (One(Left, Right), (Up, Down) | (Down, Up)) => Two((Left, Right), conv),
             (One(Right, Left), (Up, Down) | (Down, Up)) => Two((Right, Left), conv),
             (One(Up, Down), (Left, Right) | (Right, Left)) => Two((Up, Down), conv),
@@ -176,7 +176,7 @@ impl AsteroidColoniesGame {
 
         // console_log!("conv pos ix0: {ix0}, ix1: {ix1}, xrev: {x_rev}, iy0: {iy0}, iy1: {iy1}, yrev: {y_rev}, {:?}", convs);
         for (pos0, pos1) in convs.iter().zip(convs.iter().skip(1)) {
-            let cell = &self.cells[*pos0];
+            let cell = &self.tiles[*pos0];
             let staged = self.conveyor_staged.get(pos0).copied().unwrap_or(None);
             let Some(to) = Direction::from_vec([pos1[0] - pos0[0], pos1[1] - pos0[1]]) else {
                 continue;
@@ -190,7 +190,7 @@ impl AsteroidColoniesGame {
         }
 
         if let Some((pos, prev_from)) = convs.last().zip(prev_from) {
-            let cell = &self.cells[*pos];
+            let cell = &self.tiles[*pos];
             let staged = self.conveyor_staged.get(pos).copied().unwrap_or(None);
             let to = self
                 .conveyor_staged
@@ -223,7 +223,7 @@ impl AsteroidColoniesGame {
 
         let pos0 = [ix0, iy0];
         let cell = self
-            .cells
+            .tiles
             .at([ix0, iy0])
             .map(|c| c.conveyor)
             .unwrap_or(None);
@@ -238,7 +238,7 @@ impl AsteroidColoniesGame {
 
         let pos0 = [ix0, iy0];
         let cell = self
-            .cells
+            .tiles
             .at([ix0, iy0])
             .map(|c| c.conveyor)
             .unwrap_or(None);

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -7,7 +7,7 @@ use crate::{
     construction::Construction,
     task::{GlobalTask, EXCAVATE_ORE_AMOUNT, LABOR_EXCAVATE_TIME},
     transport::find_path,
-    AsteroidColoniesGame, Cell, CellState, ItemType, Pos, Tiles, WIDTH,
+    AsteroidColoniesGame, CellState, ItemType, Pos, Tiles,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -7,7 +7,7 @@ use crate::{
     construction::Construction,
     task::{GlobalTask, EXCAVATE_ORE_AMOUNT, LABOR_EXCAVATE_TIME},
     transport::find_path,
-    AsteroidColoniesGame, Cell, CellState, ItemType, Pos, WIDTH,
+    AsteroidColoniesGame, Cell, CellState, ItemType, Pos, Tiles, WIDTH,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -31,15 +31,12 @@ pub struct Crew {
 }
 
 impl Crew {
-    pub fn new_task(pos: Pos, gtask: &GlobalTask, cells: &[Cell]) -> Option<Self> {
+    pub fn new_task(pos: Pos, gtask: &GlobalTask, cells: &Tiles) -> Option<Self> {
         let (target, task) = match gtask {
             GlobalTask::Excavate(_, pos) => (*pos, CrewTask::Excavate(*pos)),
         };
         let path = find_path(pos, target, |pos| {
-            matches!(
-                cells[pos[0] as usize + pos[1] as usize * WIDTH].state,
-                CellState::Empty
-            ) || pos == target
+            matches!(cells[pos].state, CellState::Empty) || pos == target
         })?;
         Some(Self {
             pos,
@@ -51,12 +48,9 @@ impl Crew {
         })
     }
 
-    pub fn new_build(pos: Pos, dest: Pos, cells: &[Cell]) -> Option<Self> {
+    pub fn new_build(pos: Pos, dest: Pos, cells: &Tiles) -> Option<Self> {
         let path = find_path(pos, dest, |pos| {
-            matches!(
-                cells[pos[0] as usize + pos[1] as usize * WIDTH].state,
-                CellState::Empty
-            ) || pos == dest
+            matches!(cells[pos].state, CellState::Empty) || pos == dest
         })?;
         Some(Self {
             pos,
@@ -73,20 +67,14 @@ impl Crew {
         src: Pos,
         dest: Pos,
         item: ItemType,
-        cells: &[Cell],
+        cells: &Tiles,
     ) -> Option<Self> {
         let path = find_path(pos, src, |pos| {
-            matches!(
-                cells[pos[0] as usize + pos[1] as usize * WIDTH].state,
-                CellState::Empty
-            ) || pos == src
+            matches!(cells[pos].state, CellState::Empty) || pos == src
         })?;
         // Just to make sure if you can reach the destination from pickup
         if find_path(src, dest, |pos| {
-            matches!(
-                cells[pos[0] as usize + pos[1] as usize * WIDTH].state,
-                CellState::Empty
-            ) || pos == dest
+            matches!(cells[pos].state, CellState::Empty) || pos == dest
         })
         .is_none()
         {
@@ -102,12 +90,9 @@ impl Crew {
         })
     }
 
-    pub fn new_deliver(pos: Pos, dest: Pos, item: ItemType, cells: &[Cell]) -> Option<Self> {
+    pub fn new_deliver(pos: Pos, dest: Pos, item: ItemType, cells: &Tiles) -> Option<Self> {
         let path = find_path(pos, dest, |pos| {
-            matches!(
-                cells[pos[0] as usize + pos[1] as usize * WIDTH].state,
-                CellState::Empty
-            ) || pos == dest
+            matches!(cells[pos].state, CellState::Empty) || pos == dest
         })?;
         Some(Self {
             pos,
@@ -181,7 +166,7 @@ impl Crew {
         item: ItemType,
         src: Pos,
         dest: Pos,
-        cells: &[Cell],
+        cells: &Tiles,
         buildings: &mut [Building],
         constructions: &mut [Construction],
     ) {
@@ -193,10 +178,7 @@ impl Crew {
             }
             *self.inventory.entry(item).or_default() += 1;
             let path = find_path(self.pos, dest, |pos| {
-                matches!(
-                    cells[pos[0] as usize + pos[1] as usize * WIDTH].state,
-                    CellState::Empty
-                ) || pos == dest
+                matches!(cells[pos].state, CellState::Empty) || pos == dest
             })?;
             self.path = Some(path);
             self.task = CrewTask::Deliver { dst: dest, item };
@@ -287,10 +269,7 @@ impl AsteroidColoniesGame {
                     if crew.from == crew.pos {
                         try_return(crew, &mut self.buildings);
                     } else if let Some(path) = find_path(crew.pos, crew.from, |pos| {
-                        matches!(
-                            self.cells[pos[0] as usize + pos[1] as usize * WIDTH].state,
-                            CellState::Empty
-                        ) || pos == crew.from
+                        matches!(self.cells[pos].state, CellState::Empty) || pos == crew.from
                     }) {
                         crew.task = CrewTask::Return;
                         crew.path = Some(path);

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -49,7 +49,7 @@ impl AsteroidColoniesGame {
         }
         let start_ofs = |pos: [i32; 2]| {
             [
-                pos[0] + 3 + WIDTH as i32 / 8,
+                pos[0] + 24, //+ WIDTH as i32 / 8,
                 pos[1] - 5 + HEIGHT as i32 / 2,
             ]
         };

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -14,7 +14,7 @@ use crate::{
     ItemType, Pos, Position, Tile, TileState, Tiles, Xor128, HEIGHT, WIDTH,
 };
 
-pub type CalculateBackImage = Box<dyn Fn(&mut [Tile]) + Send + Sync>;
+pub type CalculateBackImage = Box<dyn Fn(&mut Tiles) + Send + Sync>;
 
 pub struct AsteroidColoniesGame {
     pub(crate) tiles: Tiles,
@@ -119,9 +119,9 @@ impl AsteroidColoniesGame {
             }
         }
         tiles.uniformify();
-        // if let Some(ref f) = calculate_back_image {
-        //     f(&mut tiles);
-        // }
+        if let Some(ref f) = calculate_back_image {
+            f(&mut tiles);
+        }
         Ok(Self {
             tiles,
             buildings,
@@ -415,9 +415,9 @@ impl AsteroidColoniesGame {
         self.transports = ser_data.transports;
         self.constructions = ser_data.constructions;
         self.rng = ser_data.rng;
-        // if let Some(ref f) = self.calculate_back_image {
-        //     f(&mut self.tiles);
-        // }
+        if let Some(ref f) = self.calculate_back_image {
+            f(&mut self.tiles);
+        }
     }
 
     pub fn serialize_chunks_digest(&self) -> bincode::Result<Vec<u8>> {

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -415,14 +415,14 @@ impl AsteroidColoniesGame {
         // }
     }
 
-    pub fn serialize_chunks_digest(&self) -> serde_json::Result<String> {
+    pub fn serialize_chunks_digest(&self) -> bincode::Result<Vec<u8>> {
         let digests = self
             .cells
             .chunks()
             .iter()
             .map(|(pos, chunk)| (pos, chunk.get_hash()))
             .collect::<HashMap<_, _>>();
-        serde_json::to_string(&digests)
+        bincode::serialize(&digests)
     }
 
     pub fn serialize_with_diffs(

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -41,8 +41,8 @@ impl AsteroidColoniesGame {
             for x in 0..WIDTH {
                 let r2 = ((x as f64 - WIDTH as f64 / 2.) as f64).powi(2)
                     + ((y as f64 - HEIGHT as f64 / 2.) as f64).powi(2);
-                if r2_thresh < r2 {
-                    cells[[x as i32, y as i32]].state = CellState::Space;
+                if r2 < r2_thresh {
+                    cells[[x as i32, y as i32]].state = CellState::Solid;
                 }
             }
         }
@@ -117,6 +117,7 @@ impl AsteroidColoniesGame {
                 cells[iofs].state = CellState::Empty;
             }
         }
+        cells.uniformify();
         // if let Some(ref f) = calculate_back_image {
         //     f(&mut cells);
         // }
@@ -366,6 +367,10 @@ impl AsteroidColoniesGame {
         self.global_time += 1;
 
         Ok(())
+    }
+
+    pub fn uniformify_tiles(&mut self) {
+        self.cells.uniformify();
     }
 
     pub fn serialize(&self, pretty: bool) -> serde_json::Result<String> {

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -9,6 +9,7 @@ use crate::{
     crew::Crew,
     hash_map, recipes,
     task::{Direction, GlobalTask, Task, MOVE_TIME},
+    tile::CHUNK_SIZE,
     transport::{find_path, Transport},
     ItemType, Pos, Position, Tile, TileState, Tiles, Xor128, HEIGHT, WIDTH,
 };
@@ -141,8 +142,12 @@ impl AsteroidColoniesGame {
         self.global_time
     }
 
-    pub fn iter_cell(&self) -> impl Iterator<Item = &Tile> {
-        self.tiles.iter().map(|(_, c)| c)
+    // pub fn iter_cell(&self) -> impl Iterator<Item = &Tile> {
+    //     self.tiles.iter().map(|(_, c)| c)
+    // }
+
+    pub fn count_tiles(&self) -> usize {
+        self.tiles.chunks.len() * CHUNK_SIZE * CHUNK_SIZE
     }
 
     pub fn cell_at(&self, pos: [i32; 2]) -> &Tile {

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -10,13 +10,13 @@ use crate::{
     hash_map, recipes,
     task::{Direction, GlobalTask, Task, MOVE_TIME},
     transport::{find_path, Transport},
-    Cell, CellState, ItemType, Pos, Xor128, HEIGHT, WIDTH,
+    Cell, CellState, ItemType, Pos, Tiles, Xor128, HEIGHT, WIDTH,
 };
 
 pub type CalculateBackImage = Box<dyn Fn(&mut [Cell]) + Send + Sync>;
 
 pub struct AsteroidColoniesGame {
-    pub(crate) cells: Vec<Cell>,
+    pub(crate) cells: Tiles,
     pub(crate) buildings: Vec<Building>,
     pub(crate) crews: Vec<Crew>,
     pub(crate) global_tasks: Vec<GlobalTask>,
@@ -35,14 +35,14 @@ pub struct AsteroidColoniesGame {
 
 impl AsteroidColoniesGame {
     pub fn new(calculate_back_image: Option<CalculateBackImage>) -> Result<Self, String> {
-        let mut cells = vec![Cell::new(); WIDTH * HEIGHT];
+        let mut cells = Tiles::new();
         let r2_thresh = (WIDTH as f64 * 3. / 8.).powi(2);
         for y in 0..HEIGHT {
             for x in 0..WIDTH {
                 let r2 = ((x as f64 - WIDTH as f64 / 2.) as f64).powi(2)
                     + ((y as f64 - HEIGHT as f64 / 2.) as f64).powi(2);
                 if r2_thresh < r2 {
-                    cells[x + y * WIDTH].state = CellState::Space;
+                    cells[[x as i32, y as i32]].state = CellState::Space;
                 }
             }
         }
@@ -72,7 +72,7 @@ impl AsteroidColoniesGame {
                 let y = pos[1] as usize + iy;
                 for ix in 0..size[0] {
                     let x = pos[0] as usize + ix;
-                    cells[x + y * WIDTH] = Cell::building();
+                    cells[[x as i32, y as i32]] = Cell::building();
                 }
             }
         }
@@ -101,27 +101,25 @@ impl AsteroidColoniesGame {
             .zip(convs.iter().skip(1).chain(std::iter::once(&convs[0])))
             .zip(convs.iter().skip(2).chain(convs.iter().take(2)))
         {
-            let [x, y] = start_ofs(*pos1);
-            let [x, y] = [x as usize, y as usize];
-            cells[x + y * WIDTH].state = CellState::Empty;
+            let ofs = start_ofs(*pos1);
+            cells[ofs].state = CellState::Empty;
             let conv = Conveyor::One(
                 Direction::from_vec([pos0[0] - pos1[0], pos0[1] - pos1[1]]).unwrap(),
                 Direction::from_vec([pos2[0] - pos1[0], pos2[1] - pos1[1]]).unwrap(),
             );
             console_log!("conv {:?}: {:?}", pos1, conv);
-            cells[x + y * WIDTH].conveyor = conv;
-            cells[x + y * WIDTH].power_grid = true;
+            cells[ofs].conveyor = conv;
+            cells[ofs].power_grid = true;
         }
         for iy in 4..10 {
             for ix in 2..7 {
-                let [x, y] = start_ofs([ix, iy]);
-                let [x, y] = [x as usize, y as usize];
-                cells[x + y * WIDTH].state = CellState::Empty;
+                let iofs = start_ofs([ix, iy]);
+                cells[iofs].state = CellState::Empty;
             }
         }
-        if let Some(ref f) = calculate_back_image {
-            f(&mut cells);
-        }
+        // if let Some(ref f) = calculate_back_image {
+        //     f(&mut cells);
+        // }
         Ok(Self {
             cells,
             buildings,
@@ -143,11 +141,11 @@ impl AsteroidColoniesGame {
     }
 
     pub fn iter_cell(&self) -> impl Iterator<Item = &Cell> {
-        self.cells.iter()
+        self.cells.iter().map(|(_, c)| c)
     }
 
     pub fn cell_at(&self, pos: [i32; 2]) -> &Cell {
-        &self.cells[pos[0] as usize + pos[1] as usize * WIDTH]
+        &self.cells[pos]
     }
 
     pub fn iter_building(&self) -> impl Iterator<Item = &Building> {
@@ -207,7 +205,7 @@ impl AsteroidColoniesGame {
         };
 
         let mut path = find_path([ix, iy], [dx, dy], |pos| {
-            let cell = &cells[pos[0] as usize + pos[1] as usize * WIDTH];
+            let cell = &cells[pos];
             !intersects(pos) && matches!(cell.state, CellState::Empty) && cell.power_grid
         })
         .ok_or_else(|| String::from("Failed to find the path"))?;
@@ -229,7 +227,7 @@ impl AsteroidColoniesGame {
         let size = type_.size();
         for jy in iy..iy + size[1] as i32 {
             for jx in ix..ix + size[0] as i32 {
-                let cell = &self.cells[jx as usize + jy as usize * WIDTH];
+                let cell = &self.cells[[jx, jy]];
                 if matches!(cell.state, CellState::Solid) {
                     return Err(String::from("Needs excavation before building"));
                 }
@@ -239,7 +237,7 @@ impl AsteroidColoniesGame {
             }
         }
 
-        let cell = &self.cells[ix as usize + iy as usize * WIDTH];
+        let cell = &self.cells[[ix, iy]];
         if !cell.power_grid {
             return Err(String::from("Power grid is required to build"));
         }
@@ -405,15 +403,15 @@ impl AsteroidColoniesGame {
         self.transports = ser_data.transports;
         self.constructions = ser_data.constructions;
         self.rng = ser_data.rng;
-        if let Some(ref f) = self.calculate_back_image {
-            f(&mut self.cells);
-        }
+        // if let Some(ref f) = self.calculate_back_image {
+        //     f(&mut self.cells);
+        // }
     }
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct SerializeGame {
-    cells: Vec<Cell>,
+    cells: Tiles,
     buildings: Vec<Building>,
     crews: Vec<Crew>,
     global_tasks: Vec<GlobalTask>,

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -142,7 +142,7 @@ impl AsteroidColoniesGame {
         self.global_time
     }
 
-    // pub fn iter_cell(&self) -> impl Iterator<Item = &Tile> {
+    // pub fn iter_tile(&self) -> impl Iterator<Item = &Tile> {
     //     self.tiles.iter().map(|(_, c)| c)
     // }
 
@@ -150,7 +150,7 @@ impl AsteroidColoniesGame {
         self.tiles.chunks.len() * CHUNK_SIZE * CHUNK_SIZE
     }
 
-    pub fn cell_at(&self, pos: [i32; 2]) -> &Tile {
+    pub fn tile_at(&self, pos: [i32; 2]) -> &Tile {
         &self.tiles[pos]
     }
 
@@ -211,8 +211,8 @@ impl AsteroidColoniesGame {
         };
 
         let mut path = find_path([ix, iy], [dx, dy], |pos| {
-            let cell = &tiles[pos];
-            !intersects(pos) && matches!(cell.state, TileState::Empty) && cell.power_grid
+            let tile = &tiles[pos];
+            !intersects(pos) && matches!(tile.state, TileState::Empty) && tile.power_grid
         })
         .ok_or_else(|| String::from("Failed to find the path"))?;
 
@@ -227,24 +227,24 @@ impl AsteroidColoniesGame {
 
     pub fn build(&mut self, ix: i32, iy: i32, type_: BuildingType) -> Result<(), String> {
         if ix < 0 || WIDTH as i32 <= ix || iy < 0 || HEIGHT as i32 <= iy {
-            return Err(String::from("Point outside cell"));
+            return Err(String::from("Point outside tile"));
         }
 
         let size = type_.size();
         for jy in iy..iy + size[1] as i32 {
             for jx in ix..ix + size[0] as i32 {
-                let cell = &self.tiles[[jx, jy]];
-                if matches!(cell.state, TileState::Solid) {
+                let tile = &self.tiles[[jx, jy]];
+                if matches!(tile.state, TileState::Solid) {
                     return Err(String::from("Needs excavation before building"));
                 }
-                if matches!(cell.state, TileState::Space) {
+                if matches!(tile.state, TileState::Space) {
                     return Err(String::from("You cannot build in space!"));
                 }
             }
         }
 
-        let cell = &self.tiles[[ix, iy]];
-        if !cell.power_grid {
+        let tile = &self.tiles[[ix, iy]];
+        if !tile.power_grid {
             return Err(String::from("Power grid is required to build"));
         }
 
@@ -313,7 +313,7 @@ impl AsteroidColoniesGame {
 
     pub fn get_recipes(&self, ix: i32, iy: i32) -> Result<Vec<&'static Recipe>, String> {
         if ix < 0 || WIDTH as i32 <= ix || iy < 0 || HEIGHT as i32 <= iy {
-            return Err(String::from("Point outside cell"));
+            return Err(String::from("Point outside tile"));
         }
         let intersects = |b: &Building| {
             let size = b.type_.size();
@@ -334,7 +334,7 @@ impl AsteroidColoniesGame {
 
     pub fn set_recipe(&mut self, ix: i32, iy: i32, name: &str) -> Result<(), String> {
         if ix < 0 || WIDTH as i32 <= ix || iy < 0 || HEIGHT as i32 <= iy {
-            return Err(String::from("Point outside cell"));
+            return Err(String::from("Point outside tile"));
         }
         let intersects = |b: &Building| {
             let size = b.type_.size();

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -49,7 +49,7 @@ impl AsteroidColoniesGame {
         }
         let start_ofs = |pos: [i32; 2]| {
             [
-                pos[0] + 24, //+ WIDTH as i32 / 8,
+                pos[0] + 23, //+ WIDTH as i32 / 8,
                 pos[1] - 5 + HEIGHT as i32 / 2,
             ]
         };
@@ -145,6 +145,10 @@ impl AsteroidColoniesGame {
     // pub fn iter_tile(&self) -> impl Iterator<Item = &Tile> {
     //     self.tiles.iter().map(|(_, c)| c)
     // }
+
+    pub fn tiles(&self) -> &Tiles {
+        &self.tiles
+    }
 
     pub fn count_tiles(&self) -> usize {
         self.tiles.chunks.len() * CHUNK_SIZE * CHUNK_SIZE

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -4,7 +4,7 @@ use crate::{building::Recipe, conveyor::Conveyor, crew::Crew, transport::Transpo
 pub use crate::{
     construction::get_build_menu,
     game::{AsteroidColoniesGame, SerializeGame},
-    tile::{Chunk, Position, Tile, TileState, Tiles},
+    tile::{Chunk, ImageIdx, Position, Tile, TileState, Tiles, CHUNK_SIZE},
     xor128::Xor128,
 };
 use serde::{Deserialize, Serialize};

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -4,6 +4,7 @@ use crate::{building::Recipe, conveyor::Conveyor, crew::Crew, transport::Transpo
 pub use crate::{
     construction::get_build_menu,
     game::{AsteroidColoniesGame, SerializeGame},
+    tile::{Cell, CellState, Chunk, Tiles},
     xor128::Xor128,
 };
 use serde::{Deserialize, Serialize};
@@ -15,6 +16,7 @@ mod crew;
 mod game;
 mod push_pull;
 pub mod task;
+mod tile;
 mod transport;
 mod xor128;
 
@@ -59,68 +61,6 @@ pub(crate) fn log(s: &str) {
 pub const TILE_SIZE: f64 = 32.;
 pub const WIDTH: usize = 100;
 pub const HEIGHT: usize = 100;
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-pub enum CellState {
-    Solid,
-    Empty,
-    Space,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-pub struct Cell {
-    pub state: CellState,
-    pub power_grid: bool,
-    pub conveyor: Conveyor,
-    /// The index into the background image for quick rendering
-    #[serde(skip)]
-    pub image_lt: u8,
-    #[serde(skip)]
-    pub image_lb: u8,
-    #[serde(skip)]
-    pub image_rb: u8,
-    #[serde(skip)]
-    pub image_rt: u8,
-}
-
-impl Cell {
-    const fn new() -> Self {
-        Self {
-            state: CellState::Solid,
-            power_grid: false,
-            conveyor: Conveyor::None,
-            image_lt: 0,
-            image_lb: 0,
-            image_rb: 0,
-            image_rt: 0,
-        }
-    }
-
-    #[allow(dead_code)]
-    const fn new_with_conveyor(conveyor: Conveyor) -> Self {
-        Self {
-            state: CellState::Empty,
-            power_grid: false,
-            conveyor,
-            image_lt: 0,
-            image_lb: 0,
-            image_rb: 0,
-            image_rt: 0,
-        }
-    }
-
-    const fn building() -> Self {
-        Self {
-            state: CellState::Empty,
-            power_grid: true,
-            conveyor: Conveyor::None,
-            image_lt: 8,
-            image_lb: 8,
-            image_rb: 8,
-            image_rt: 8,
-        }
-    }
-}
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub enum ItemType {

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -4,7 +4,7 @@ use crate::{building::Recipe, conveyor::Conveyor, crew::Crew, transport::Transpo
 pub use crate::{
     construction::get_build_menu,
     game::{AsteroidColoniesGame, SerializeGame},
-    tile::{Cell, CellState, Chunk, ChunkDigest, Position, Tiles},
+    tile::{Chunk, ChunkDigest, Position, Tile, TileState, Tiles},
     xor128::Xor128,
 };
 use serde::{Deserialize, Serialize};

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -4,7 +4,7 @@ use crate::{building::Recipe, conveyor::Conveyor, crew::Crew, transport::Transpo
 pub use crate::{
     construction::get_build_menu,
     game::{AsteroidColoniesGame, SerializeGame},
-    tile::{Chunk, ImageIdx, Position, Tile, TileState, Tiles, CHUNK_SIZE},
+    tile::{new_hasher, Chunk, ImageIdx, Position, Tile, TileState, Tiles, CHUNK_SIZE},
     xor128::Xor128,
 };
 use serde::{Deserialize, Serialize};

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -4,7 +4,7 @@ use crate::{building::Recipe, conveyor::Conveyor, crew::Crew, transport::Transpo
 pub use crate::{
     construction::get_build_menu,
     game::{AsteroidColoniesGame, SerializeGame},
-    tile::{Chunk, ChunkDigest, Position, Tile, TileState, Tiles},
+    tile::{Chunk, Position, Tile, TileState, Tiles},
     xor128::Xor128,
 };
 use serde::{Deserialize, Serialize};

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -4,7 +4,7 @@ use crate::{building::Recipe, conveyor::Conveyor, crew::Crew, transport::Transpo
 pub use crate::{
     construction::get_build_menu,
     game::{AsteroidColoniesGame, SerializeGame},
-    tile::{Cell, CellState, Chunk, Tiles},
+    tile::{Cell, CellState, Chunk, ChunkDigest, Position, Tiles},
     xor128::Xor128,
 };
 use serde::{Deserialize, Serialize};

--- a/game-logic/src/push_pull.rs
+++ b/game-logic/src/push_pull.rs
@@ -9,7 +9,7 @@ use crate::{
     conveyor::Conveyor,
     task::Direction,
     transport::{expected_deliveries, find_multipath_should_expand, CPos, LevelTarget, Transport},
-    Cell, ItemType, Pos, WIDTH,
+    Cell, ItemType, Pos, Tiles, WIDTH,
 };
 
 /// An abstraction of tile map where you can pick a tile from a position.
@@ -27,6 +27,12 @@ impl TileSampler for &[Cell] {
 impl TileSampler for Vec<Cell> {
     fn at(&self, pos: [i32; 2]) -> Option<&Cell> {
         Some(&self[pos[0] as usize + pos[1] as usize * WIDTH])
+    }
+}
+
+impl TileSampler for Tiles {
+    fn at(&self, pos: [i32; 2]) -> Option<&Cell> {
+        Some(&self[pos])
     }
 }
 

--- a/game-logic/src/push_pull.rs
+++ b/game-logic/src/push_pull.rs
@@ -224,10 +224,10 @@ fn push_pull_passable(
     start_neighbors: &HashSet<Pos>,
     pos: Pos,
 ) -> bool {
-    let Some(cell) = tiles.at(pos) else {
+    let Some(tile) = tiles.at(pos) else {
         return false;
     };
-    if cell.conveyor.is_some() && start_neighbors.contains(&pos) {
+    if tile.conveyor.is_some() && start_neighbors.contains(&pos) {
         // crate::console_log!("next to start");
         return true;
     }
@@ -235,8 +235,8 @@ fn push_pull_passable(
         return false;
     }
     from_direction
-        .map(|from| cell.conveyor.has_from(from.reverse()))
-        .unwrap_or_else(|| cell.conveyor.is_some())
+        .map(|from| tile.conveyor.has_from(from.reverse()))
+        .unwrap_or_else(|| tile.conveyor.is_some())
 }
 
 fn prev_tile_connects_to(tiles: &impl TileSampler, from_dir: Option<Direction>, pos: Pos) -> bool {
@@ -245,12 +245,12 @@ fn prev_tile_connects_to(tiles: &impl TileSampler, from_dir: Option<Direction>, 
     };
     let dir_vec = dir.to_vec();
     let prev_pos = [pos[0] - dir_vec[0], pos[1] - dir_vec[1]];
-    let Some(prev_cell) = tiles.at(prev_pos) else {
+    let Some(prev_tile) = tiles.at(prev_pos) else {
         return true;
     };
-    // If the previous cell didn't have a conveyor, it's not a failure, because we want to be
+    // If the previous tile didn't have a conveyor, it's not a failure, because we want to be
     // able to depart from a building.
-    prev_cell.conveyor.has_to(dir)
+    prev_tile.conveyor.has_to(dir)
 }
 
 fn push_pull_should_expand(
@@ -260,23 +260,23 @@ fn push_pull_should_expand(
     from: Option<Direction>,
 ) -> LevelTarget {
     use Direction::*;
-    let Some(cell) = tiles.at(cpos.pos) else {
+    let Some(tile) = tiles.at(cpos.pos) else {
         return LevelTarget::One;
     };
-    let conv = &cell.conveyor;
+    let conv = &tile.conveyor;
     let dir_vec = to.to_vec();
     let next_pos = [cpos.pos[0] + dir_vec[0], cpos.pos[1] + dir_vec[1]];
-    let Some(next_cell) = tiles.at(next_pos) else {
+    let Some(next_tile) = tiles.at(next_pos) else {
         return LevelTarget::One;
     };
-    let next_conv = &next_cell.conveyor;
+    let next_conv = &next_tile.conveyor;
     if next_conv.has_two()
         && (conv.has_to(Up) || conv.has_to(Down))
         && (next_conv.has(Up) || next_conv.has(Down))
     {
         return LevelTarget::Two;
     }
-    match cell.conveyor {
+    match tile.conveyor {
         Conveyor::One(_, _) => LevelTarget::One,
         Conveyor::Two(_, _) => {
             if from.is_some_and(|from| to == from) {

--- a/game-logic/src/push_pull.rs
+++ b/game-logic/src/push_pull.rs
@@ -9,29 +9,29 @@ use crate::{
     conveyor::Conveyor,
     task::Direction,
     transport::{expected_deliveries, find_multipath_should_expand, CPos, LevelTarget, Transport},
-    Cell, ItemType, Pos, Tiles, WIDTH,
+    ItemType, Pos, Tile, Tiles, WIDTH,
 };
 
 /// An abstraction of tile map where you can pick a tile from a position.
 /// Used to mock in unit tests.
 pub(crate) trait TileSampler {
-    fn at(&self, pos: [i32; 2]) -> Option<&Cell>;
+    fn at(&self, pos: [i32; 2]) -> Option<&Tile>;
 }
 
-impl TileSampler for &[Cell] {
-    fn at(&self, pos: [i32; 2]) -> Option<&Cell> {
+impl TileSampler for &[Tile] {
+    fn at(&self, pos: [i32; 2]) -> Option<&Tile> {
         Some(&self[pos[0] as usize + pos[1] as usize * WIDTH])
     }
 }
 
-impl TileSampler for Vec<Cell> {
-    fn at(&self, pos: [i32; 2]) -> Option<&Cell> {
+impl TileSampler for Vec<Tile> {
+    fn at(&self, pos: [i32; 2]) -> Option<&Tile> {
         Some(&self[pos[0] as usize + pos[1] as usize * WIDTH])
     }
 }
 
 impl TileSampler for Tiles {
-    fn at(&self, pos: [i32; 2]) -> Option<&Cell> {
+    fn at(&self, pos: [i32; 2]) -> Option<&Tile> {
         Some(&self[pos])
     }
 }
@@ -39,7 +39,7 @@ impl TileSampler for Tiles {
 /// Pull inputs over transportation network
 pub(crate) fn pull_inputs(
     inputs: &HashMap<ItemType, usize>,
-    cells: &impl TileSampler,
+    tiles: &impl TileSampler,
     transports: &mut Vec<Transport>,
     this_pos: Pos,
     this_size: [usize; 2],
@@ -77,9 +77,9 @@ pub(crate) fn pull_inputs(
                 if intersects_goal(pos) {
                     return true;
                 }
-                push_pull_passable(cells, from_direction, &start_neighbors, pos)
+                push_pull_passable(tiles, from_direction, &start_neighbors, pos)
             },
-            |to, pos, from| push_pull_should_expand(cells, to, pos, from),
+            |to, pos, from| push_pull_should_expand(tiles, to, pos, from),
         );
         let Some(path) = path else {
             continue;
@@ -115,7 +115,7 @@ fn find_from_other_inventory_mut<'a>(
     })
 }
 
-/// Return an iterator over cells covering a rectangle specified by left top corner position and a size.
+/// Return an iterator over tiles covering a rectangle specified by left top corner position and a size.
 pub(crate) fn rect_iter(pos: Pos, size: [usize; 2]) -> impl Iterator<Item = Pos> {
     (0..size[0])
         .map(move |ix| (0..size[1]).map(move |iy| [pos[0] + ix as i32, pos[1] + iy as i32]))
@@ -144,7 +144,7 @@ impl HasInventory for Building {
 }
 
 pub(crate) fn push_outputs(
-    cells: &impl TileSampler,
+    tiles: &impl TileSampler,
     transports: &mut Vec<Transport>,
     this: &mut impl HasInventory,
     first: &mut [Building],
@@ -187,9 +187,9 @@ pub(crate) fn push_outputs(
                 if intersects(pos) {
                     return true;
                 }
-                push_pull_passable(cells, from_direction, &start_neighbors, pos)
+                push_pull_passable(tiles, from_direction, &start_neighbors, pos)
             },
-            |to, pos, from| push_pull_should_expand(cells, to, pos, from),
+            |to, pos, from| push_pull_should_expand(tiles, to, pos, from),
         )?;
         Some((b, path))
     });
@@ -219,19 +219,19 @@ pub(crate) fn push_outputs(
 }
 
 fn push_pull_passable(
-    cells: &impl TileSampler,
+    tiles: &impl TileSampler,
     from_direction: Option<Direction>,
     start_neighbors: &HashSet<Pos>,
     pos: Pos,
 ) -> bool {
-    let Some(cell) = cells.at(pos) else {
+    let Some(cell) = tiles.at(pos) else {
         return false;
     };
     if cell.conveyor.is_some() && start_neighbors.contains(&pos) {
         // crate::console_log!("next to start");
         return true;
     }
-    if !prev_tile_connects_to(cells, from_direction, pos) {
+    if !prev_tile_connects_to(tiles, from_direction, pos) {
         return false;
     }
     from_direction
@@ -239,13 +239,13 @@ fn push_pull_passable(
         .unwrap_or_else(|| cell.conveyor.is_some())
 }
 
-fn prev_tile_connects_to(cells: &impl TileSampler, from_dir: Option<Direction>, pos: Pos) -> bool {
+fn prev_tile_connects_to(tiles: &impl TileSampler, from_dir: Option<Direction>, pos: Pos) -> bool {
     let Some(dir) = from_dir else {
         return true;
     };
     let dir_vec = dir.to_vec();
     let prev_pos = [pos[0] - dir_vec[0], pos[1] - dir_vec[1]];
-    let Some(prev_cell) = cells.at(prev_pos) else {
+    let Some(prev_cell) = tiles.at(prev_pos) else {
         return true;
     };
     // If the previous cell didn't have a conveyor, it's not a failure, because we want to be
@@ -254,19 +254,19 @@ fn prev_tile_connects_to(cells: &impl TileSampler, from_dir: Option<Direction>, 
 }
 
 fn push_pull_should_expand(
-    cells: &impl TileSampler,
+    tiles: &impl TileSampler,
     to: Direction,
     cpos: CPos,
     from: Option<Direction>,
 ) -> LevelTarget {
     use Direction::*;
-    let Some(cell) = cells.at(cpos.pos) else {
+    let Some(cell) = tiles.at(cpos.pos) else {
         return LevelTarget::One;
     };
     let conv = &cell.conveyor;
     let dir_vec = to.to_vec();
     let next_pos = [cpos.pos[0] + dir_vec[0], cpos.pos[1] + dir_vec[1]];
-    let Some(next_cell) = cells.at(next_pos) else {
+    let Some(next_cell) = tiles.at(next_pos) else {
         return LevelTarget::One;
     };
     let next_conv = &next_cell.conveyor;

--- a/game-logic/src/push_pull/tests.rs
+++ b/game-logic/src/push_pull/tests.rs
@@ -4,17 +4,17 @@ use crate::{building::BuildingType, Inventory};
 struct MockTiles;
 
 impl TileSampler for MockTiles {
-    fn at(&self, pos: [i32; 2]) -> Option<&Cell> {
+    fn at(&self, pos: [i32; 2]) -> Option<&Tile> {
         use {Conveyor::*, Direction::*};
-        static SOLID: Cell = Cell::new();
-        static RD: Cell = Cell::new_with_conveyor(One(Right, Down));
-        static UD: Cell = Cell::new_with_conveyor(One(Up, Down));
-        static UR: Cell = Cell::new_with_conveyor(One(Up, Right));
-        static LR: Cell = Cell::new_with_conveyor(One(Left, Right));
-        static LU: Cell = Cell::new_with_conveyor(One(Left, Up));
-        static DU: Cell = Cell::new_with_conveyor(One(Down, Up));
-        static DL: Cell = Cell::new_with_conveyor(One(Down, Left));
-        static RL: Cell = Cell::new_with_conveyor(One(Right, Left));
+        static SOLID: Tile = Tile::new();
+        static RD: Tile = Tile::new_with_conveyor(One(Right, Down));
+        static UD: Tile = Tile::new_with_conveyor(One(Up, Down));
+        static UR: Tile = Tile::new_with_conveyor(One(Up, Right));
+        static LR: Tile = Tile::new_with_conveyor(One(Left, Right));
+        static LU: Tile = Tile::new_with_conveyor(One(Left, Up));
+        static DU: Tile = Tile::new_with_conveyor(One(Down, Up));
+        static DL: Tile = Tile::new_with_conveyor(One(Down, Left));
+        static RL: Tile = Tile::new_with_conveyor(One(Right, Left));
         let ret = match pos {
             [0, 0] => Some(&RD),
             [0, 1] => Some(&UD),
@@ -117,18 +117,18 @@ fn test_push_outputs() {
 struct MockTiles2;
 
 impl TileSampler for MockTiles2 {
-    fn at(&self, pos: [i32; 2]) -> Option<&Cell> {
+    fn at(&self, pos: [i32; 2]) -> Option<&Tile> {
         use {Conveyor::*, Direction::*};
-        static SOLID: Cell = Cell::new();
-        static RD: Cell = Cell::new_with_conveyor(One(Right, Down));
-        static UD: Cell = Cell::new_with_conveyor(One(Up, Down));
-        static UR: Cell = Cell::new_with_conveyor(One(Up, Right));
-        static LR: Cell = Cell::new_with_conveyor(One(Left, Right));
-        static LU: Cell = Cell::new_with_conveyor(One(Left, Up));
-        static DU: Cell = Cell::new_with_conveyor(One(Down, Up));
-        static DL: Cell = Cell::new_with_conveyor(One(Down, Left));
-        static RL: Cell = Cell::new_with_conveyor(One(Right, Left));
-        static DULR: Cell = Cell::new_with_conveyor(Two((Down, Up), (Left, Right)));
+        static SOLID: Tile = Tile::new();
+        static RD: Tile = Tile::new_with_conveyor(One(Right, Down));
+        static UD: Tile = Tile::new_with_conveyor(One(Up, Down));
+        static UR: Tile = Tile::new_with_conveyor(One(Up, Right));
+        static LR: Tile = Tile::new_with_conveyor(One(Left, Right));
+        static LU: Tile = Tile::new_with_conveyor(One(Left, Up));
+        static DU: Tile = Tile::new_with_conveyor(One(Down, Up));
+        static DL: Tile = Tile::new_with_conveyor(One(Down, Left));
+        static RL: Tile = Tile::new_with_conveyor(One(Right, Left));
+        static DULR: Tile = Tile::new_with_conveyor(Two((Down, Up), (Left, Right)));
         let ret = match pos {
             [0, 0] => Some(&RD),
             [0, 1] => Some(&UD),
@@ -154,14 +154,14 @@ impl TileSampler for MockTiles2 {
 
 fn print_board(tiles: &impl TileSampler) {
     use Direction::*;
-    let vert_bar = |t: &Cell, c| {
+    let vert_bar = |t: &Tile, c| {
         if t.conveyor.has_from(c) || t.conveyor.has_to(c) {
             "|"
         } else {
             " "
         }
     };
-    let horz_bar = |t: &Cell, c| {
+    let horz_bar = |t: &Tile, c| {
         if t.conveyor.has_from(c) || t.conveyor.has_to(c) {
             "-"
         } else {

--- a/game-logic/src/task.rs
+++ b/game-logic/src/task.rs
@@ -142,15 +142,15 @@ impl AsteroidColoniesGame {
     }
 
     pub fn build_power_grid(&mut self, ix: i32, iy: i32) -> Result<bool, String> {
-        let cell = &self.tiles[[ix, iy]];
-        if matches!(cell.state, TileState::Solid) {
+        let tile = &self.tiles[[ix, iy]];
+        if matches!(tile.state, TileState::Solid) {
             return Err(String::from("Needs excavation before building power grid"));
         }
-        if matches!(cell.state, TileState::Space) {
+        if matches!(tile.state, TileState::Space) {
             return Err(String::from("You cannot build power grid in space!"));
         }
-        if cell.power_grid {
-            return Err(String::from("Power grid is already installed in this cell"));
+        if tile.power_grid {
+            return Err(String::from("Power grid is already installed in this tile"));
         }
         self.constructions
             .push(Construction::new_power_grid([ix, iy]));
@@ -158,11 +158,11 @@ impl AsteroidColoniesGame {
     }
 
     pub fn move_item(&mut self, ix: i32, iy: i32) -> Result<bool, String> {
-        let cell = &self.tiles[[ix, iy]];
-        if matches!(cell.state, TileState::Solid) {
+        let tile = &self.tiles[[ix, iy]];
+        if matches!(tile.state, TileState::Solid) {
             return Err(String::from("Needs excavation before building conveyor"));
         }
-        if !cell.conveyor.is_some() {
+        if !tile.conveyor.is_some() {
             return Err(String::from("Conveyor is needed to move items"));
         }
         let Some(_dest) = self
@@ -188,8 +188,8 @@ impl AsteroidColoniesGame {
     pub(super) fn _is_clear(&self, ix: i32, iy: i32, size: [usize; 2]) -> bool {
         for jy in iy..iy + size[1] as i32 {
             for jx in ix..ix + size[0] as i32 {
-                let j_cell = &self.tiles[[jx, jy]];
-                if matches!(j_cell.state, TileState::Solid) {
+                let j_tile = &self.tiles[[jx, jy]];
+                if matches!(j_tile.state, TileState::Solid) {
                     return false;
                 }
             }

--- a/game-logic/src/task.rs
+++ b/game-logic/src/task.rs
@@ -57,6 +57,12 @@ pub enum Direction {
     Down,
 }
 
+impl std::hash::Hash for Direction {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        ((*self) as u8).hash(state)
+    }
+}
+
 impl Direction {
     pub(crate) const fn all() -> [Direction; 4] {
         [Self::Left, Self::Up, Self::Right, Self::Down]

--- a/game-logic/src/task.rs
+++ b/game-logic/src/task.rs
@@ -7,7 +7,7 @@ use crate::{
     construction::Construction,
     game::CalculateBackImage,
     transport::find_path,
-    AsteroidColoniesGame, Cell, CellState, ItemType, Pos, Tiles, WIDTH,
+    AsteroidColoniesGame, CellState, ItemType, Pos, Tiles,
 };
 
 pub const EXCAVATE_TIME: f64 = 10.;
@@ -219,7 +219,7 @@ impl AsteroidColoniesGame {
         cells: &mut Tiles,
         building: &mut Building,
         power_ratio: f64,
-        calculate_back_image: Option<&mut CalculateBackImage>,
+        _calculate_back_image: Option<&mut CalculateBackImage>,
     ) -> Option<(ItemType, [i32; 2])> {
         match building.task {
             Task::Excavate(ref mut t, dir) => {

--- a/game-logic/src/task.rs
+++ b/game-logic/src/task.rs
@@ -225,7 +225,7 @@ impl AsteroidColoniesGame {
         tiles: &mut Tiles,
         building: &mut Building,
         power_ratio: f64,
-        _calculate_back_image: Option<&mut CalculateBackImage>,
+        calculate_back_image: Option<&mut CalculateBackImage>,
     ) -> Option<(ItemType, [i32; 2])> {
         match building.task {
             Task::Excavate(ref mut t, dir) => {
@@ -238,9 +238,9 @@ impl AsteroidColoniesGame {
                     let dir_vec = dir.to_vec();
                     let pos = [building.pos[0] + dir_vec[0], building.pos[1] + dir_vec[1]];
                     tiles[pos].state = TileState::Empty;
-                    // if let Some(f) = calculate_back_image {
-                    //     f(tiles);
-                    // }
+                    if let Some(f) = calculate_back_image {
+                        f(tiles);
+                    }
                 } else {
                     *t = (*t - power_ratio).max(0.);
                 }
@@ -304,9 +304,9 @@ impl AsteroidColoniesGame {
             match task {
                 GlobalTask::Excavate(t, pos) if *t <= 0. => {
                     self.tiles[*pos].state = TileState::Empty;
-                    // if let Some(ref f) = self.calculate_back_image {
-                    //     f(&mut self.tiles);
-                    // }
+                    if let Some(ref f) = self.calculate_back_image {
+                        f(&mut self.tiles);
+                    }
                 }
                 _ => {}
             }

--- a/game-logic/src/tile.rs
+++ b/game-logic/src/tile.rs
@@ -1,0 +1,217 @@
+use std::{
+    collections::HashMap,
+    ops::{Index, IndexMut},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{conveyor::Conveyor, Pos};
+
+pub const CHUNK_SIZE: usize = 16;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum CellState {
+    Solid,
+    Empty,
+    Space,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct Cell {
+    pub state: CellState,
+    pub power_grid: bool,
+    pub conveyor: Conveyor,
+    /// The index into the background image for quick rendering
+    #[serde(skip)]
+    pub image_lt: u8,
+    #[serde(skip)]
+    pub image_lb: u8,
+    #[serde(skip)]
+    pub image_rb: u8,
+    #[serde(skip)]
+    pub image_rt: u8,
+}
+
+impl Cell {
+    pub const fn new() -> Self {
+        Self {
+            state: CellState::Solid,
+            power_grid: false,
+            conveyor: Conveyor::None,
+            image_lt: 0,
+            image_lb: 0,
+            image_rb: 0,
+            image_rt: 0,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) const fn new_with_conveyor(conveyor: Conveyor) -> Self {
+        Self {
+            state: CellState::Empty,
+            power_grid: false,
+            conveyor,
+            image_lt: 0,
+            image_lb: 0,
+            image_rb: 0,
+            image_rt: 0,
+        }
+    }
+
+    pub(crate) const fn building() -> Self {
+        Self {
+            state: CellState::Empty,
+            power_grid: true,
+            conveyor: Conveyor::None,
+            image_lt: 8,
+            image_lb: 8,
+            image_rb: 8,
+            image_rt: 8,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Chunk {
+    tiles: Vec<Cell>,
+}
+
+impl Chunk {
+    pub fn new() -> Self {
+        Self {
+            tiles: vec![Cell::new(); CHUNK_SIZE * CHUNK_SIZE],
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Tiles {
+    chunks: HashMap<Pos, Chunk>,
+}
+
+impl Tiles {
+    pub fn new() -> Self {
+        Self {
+            chunks: HashMap::new(),
+        }
+    }
+
+    pub fn iter(&self) -> TilesIter {
+        TilesIter::new(self)
+    }
+
+    pub fn try_get_mut(&mut self, index: [i32; 2]) -> Option<&mut Cell> {
+        let chunk_pos = [
+            index[0].div_euclid(CHUNK_SIZE as i32),
+            index[1].div_euclid(CHUNK_SIZE as i32),
+        ];
+        self.chunks.get_mut(&chunk_pos).map(|chunk| {
+            let tile_pos = [
+                index[0].rem_euclid(CHUNK_SIZE as i32),
+                index[1].rem_euclid(CHUNK_SIZE as i32),
+            ];
+            &mut chunk.tiles[tile_pos[0] as usize + tile_pos[1] as usize * CHUNK_SIZE]
+        })
+    }
+}
+
+impl Index<[i32; 2]> for Tiles {
+    type Output = Cell;
+    fn index(&self, index: [i32; 2]) -> &Self::Output {
+        static SPACE: Cell = Cell::new();
+        let chunk_pos = [
+            index[0].div_euclid(CHUNK_SIZE as i32),
+            index[1].div_euclid(CHUNK_SIZE as i32),
+        ];
+        self.chunks
+            .get(&chunk_pos)
+            .map(|chunk| {
+                let tile_pos = [
+                    index[0].rem_euclid(CHUNK_SIZE as i32),
+                    index[1].rem_euclid(CHUNK_SIZE as i32),
+                ];
+                &chunk.tiles[tile_pos[0] as usize + tile_pos[1] as usize * CHUNK_SIZE]
+            })
+            .unwrap_or(&SPACE)
+    }
+}
+
+impl IndexMut<[i32; 2]> for Tiles {
+    /// Allocate a chunk if the given position doesn't have one.
+    fn index_mut(&mut self, index: [i32; 2]) -> &mut Self::Output {
+        let chunk_pos = [
+            index[0].div_euclid(CHUNK_SIZE as i32),
+            index[1].div_euclid(CHUNK_SIZE as i32),
+        ];
+        let chunk = self.chunks.entry(chunk_pos).or_insert_with(Chunk::new);
+        let tile_pos = [
+            index[0].rem_euclid(CHUNK_SIZE as i32),
+            index[1].rem_euclid(CHUNK_SIZE as i32),
+        ];
+        &mut chunk.tiles[tile_pos[0] as usize + tile_pos[1] as usize * CHUNK_SIZE]
+    }
+}
+
+pub struct TilesIter<'a> {
+    // tiles: &'a Tiles,
+    iter_chunks: Option<Box<dyn Iterator<Item = (&'a Pos, &'a Chunk)> + 'a>>,
+    chunk_pos: Option<Pos>,
+    iter: Option<Box<dyn Iterator<Item = (usize, &'a Cell)> + 'a>>,
+}
+
+impl<'a> TilesIter<'a> {
+    pub fn new(tiles: &'a Tiles) -> Self {
+        let mut iter_chunks = tiles.chunks.iter();
+        let first = iter_chunks.next();
+        let chunk_pos = first.map(|(k, _)| *k);
+        let iter = first.map(|(_, v)| Box::new(v.tiles.iter().enumerate()) as _);
+        Self {
+            // tiles,
+            iter_chunks: Some(Box::new(iter_chunks) as _),
+            chunk_pos,
+            iter,
+        }
+    }
+}
+
+impl<'a> Iterator for TilesIter<'a> {
+    type Item = (Pos, &'a Cell);
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some(iter) = self.iter.as_mut() else {
+            return None;
+        };
+        let Some(chunk_pos) = self.chunk_pos else {
+            return None;
+        };
+        match iter.next() {
+            Some((i, item)) => {
+                let pos = [(i % CHUNK_SIZE) as i32, (i / CHUNK_SIZE) as i32];
+                Some((
+                    [
+                        chunk_pos[0] * CHUNK_SIZE as i32 + pos[0],
+                        chunk_pos[1] * CHUNK_SIZE as i32 + pos[1],
+                    ],
+                    item,
+                ))
+            }
+            None => {
+                let Some((chunk_pos, chunk)) = self.iter_chunks.as_mut().and_then(|i| i.next())
+                else {
+                    return None;
+                };
+                let mut iter = chunk.tiles.iter().enumerate();
+                let ret = iter.next();
+                self.iter = Some(Box::new(iter) as _);
+                ret.map(|(i, c)| {
+                    (
+                        [
+                            chunk_pos[0] * CHUNK_SIZE as i32 + i.rem_euclid(CHUNK_SIZE) as i32,
+                            chunk_pos[1] * CHUNK_SIZE as i32 + i.div_euclid(CHUNK_SIZE) as i32,
+                        ],
+                        c,
+                    )
+                })
+            }
+        }
+    }
+}

--- a/game-logic/src/tile.rs
+++ b/game-logic/src/tile.rs
@@ -159,11 +159,6 @@ impl Chunk {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ChunkDigest {
-    hash: u64,
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Position {
     pub x: i32,
@@ -252,9 +247,9 @@ impl Tiles {
         Ok(Self { chunks })
     }
 
-    pub fn iter(&self) -> TilesIter {
-        TilesIter::new(self)
-    }
+    // pub fn iter(&self) -> TilesIter {
+    //     TilesIter::new(self)
+    // }
 
     pub fn chunks(&self) -> &HashMap<Position, Chunk> {
         &self.chunks
@@ -344,6 +339,7 @@ impl IndexMut<[i32; 2]> for Tiles {
     }
 }
 
+#[allow(dead_code)]
 pub struct TilesIter<'a> {
     // tiles: &'a Tiles,
     iter_chunks: Option<Box<dyn Iterator<Item = (&'a Position, &'a Chunk)> + 'a>>,
@@ -351,6 +347,7 @@ pub struct TilesIter<'a> {
     iter: Option<Box<dyn Iterator<Item = (usize, &'a Tile)> + 'a>>,
 }
 
+#[allow(dead_code)]
 impl<'a> TilesIter<'a> {
     pub fn new(tiles: &'a Tiles) -> Self {
         let mut iter_chunks = tiles.chunks.iter();

--- a/game-logic/src/tile.rs
+++ b/game-logic/src/tile.rs
@@ -24,7 +24,7 @@ impl Hash for TileState {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Tile {
     pub state: TileState,
     pub power_grid: bool,
@@ -32,16 +32,6 @@ pub struct Tile {
     #[serde(skip)]
     pub image_idx: ImageIdx,
 }
-
-impl PartialEq for Tile {
-    fn eq(&self, other: &Self) -> bool {
-        self.state == other.state
-            && self.power_grid == other.power_grid
-            && self.conveyor == other.conveyor
-    }
-}
-
-impl Eq for Tile {}
 
 impl Hash for Tile {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -81,15 +71,12 @@ impl Tile {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
 /// The index into the background image for quick rendering
 pub struct ImageIdx {
     pub lt: u8,
-    #[serde(skip)]
     pub lb: u8,
-    #[serde(skip)]
     pub rb: u8,
-    #[serde(skip)]
     pub rt: u8,
 }
 
@@ -123,7 +110,7 @@ impl std::hash::Hash for Chunk {
     }
 }
 
-fn new_hasher() -> FnvHasher {
+pub fn new_hasher() -> FnvHasher {
     FnvHasher::default()
 }
 
@@ -337,7 +324,7 @@ impl IndexMut<[i32; 2]> for Tiles {
                 &mut tiles[tile_pos[0] as usize + tile_pos[1] as usize * CHUNK_SIZE]
             }
             Chunk::Uniform(tile, _) => {
-                let mut tiles = vec![Tile::new(); CHUNK_SIZE * CHUNK_SIZE];
+                let mut tiles = vec![*tile; CHUNK_SIZE * CHUNK_SIZE];
                 tiles[tile_pos[0] as usize + tile_pos[1] as usize * CHUNK_SIZE] = *tile;
                 let mut hasher = new_hasher();
                 for tile in &tiles {

--- a/game-logic/src/tile.rs
+++ b/game-logic/src/tile.rs
@@ -117,8 +117,8 @@ fn new_hasher() -> FnvHasher {
 impl Chunk {
     pub fn new() -> Self {
         let mut hasher = new_hasher();
-        let cell = Tile::new();
-        cell.hash(&mut hasher);
+        let tile = Tile::new();
+        tile.hash(&mut hasher);
         let hash = hasher.finish();
         Self::Uniform(Tile::new(), hash)
     }

--- a/game-logic/src/tile.rs
+++ b/game-logic/src/tile.rs
@@ -24,20 +24,13 @@ impl Hash for TileState {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Tile {
     pub state: TileState,
     pub power_grid: bool,
     pub conveyor: Conveyor,
-    /// The index into the background image for quick rendering
     #[serde(skip)]
-    pub image_lt: u8,
-    #[serde(skip)]
-    pub image_lb: u8,
-    #[serde(skip)]
-    pub image_rb: u8,
-    #[serde(skip)]
-    pub image_rt: u8,
+    pub image_idx: ImageIdx,
 }
 
 impl PartialEq for Tile {
@@ -47,6 +40,8 @@ impl PartialEq for Tile {
             && self.conveyor == other.conveyor
     }
 }
+
+impl Eq for Tile {}
 
 impl Hash for Tile {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -62,10 +57,7 @@ impl Tile {
             state: TileState::Space,
             power_grid: false,
             conveyor: Conveyor::None,
-            image_lt: 0,
-            image_lb: 0,
-            image_rb: 0,
-            image_rt: 0,
+            image_idx: ImageIdx::new(),
         }
     }
 
@@ -75,10 +67,7 @@ impl Tile {
             state: TileState::Empty,
             power_grid: false,
             conveyor,
-            image_lt: 0,
-            image_lb: 0,
-            image_rb: 0,
-            image_rt: 0,
+            image_idx: ImageIdx::new(),
         }
     }
 
@@ -87,10 +76,34 @@ impl Tile {
             state: TileState::Empty,
             power_grid: true,
             conveyor: Conveyor::None,
-            image_lt: 8,
-            image_lb: 8,
-            image_rb: 8,
-            image_rt: 8,
+            image_idx: ImageIdx::splat(8),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default)]
+/// The index into the background image for quick rendering
+pub struct ImageIdx {
+    pub lt: u8,
+    #[serde(skip)]
+    pub lb: u8,
+    #[serde(skip)]
+    pub rb: u8,
+    #[serde(skip)]
+    pub rt: u8,
+}
+
+impl ImageIdx {
+    pub const fn new() -> Self {
+        Self::splat(0)
+    }
+
+    pub const fn splat(idx: u8) -> Self {
+        Self {
+            lt: idx,
+            lb: idx,
+            rb: idx,
+            rt: idx,
         }
     }
 }
@@ -253,6 +266,10 @@ impl Tiles {
 
     pub fn chunks(&self) -> &HashMap<Position, Chunk> {
         &self.chunks
+    }
+
+    pub fn chunks_mut(&mut self) -> &mut HashMap<Position, Chunk> {
+        &mut self.chunks
     }
 
     pub fn try_get_mut(&mut self, index: [i32; 2]) -> Option<&mut Tile> {

--- a/game-logic/src/transport.rs
+++ b/game-logic/src/transport.rs
@@ -77,7 +77,7 @@ impl AsteroidColoniesGame {
                         std::iter::once(t.dest),
                         |pos| pos == t.src,
                         |from_direction, pos| {
-                            let cell = &cells[pos[0] as usize + pos[1] as usize * WIDTH];
+                            let cell = &cells[pos];
                             if let Some(from_direction) = from_direction {
                                 matches!(cell.conveyor, Conveyor::One(_, dir) if dir == from_direction)
                                     && cell.conveyor.is_some()

--- a/game-logic/src/transport.rs
+++ b/game-logic/src/transport.rs
@@ -72,12 +72,12 @@ impl AsteroidColoniesGame {
             if t.path.len() <= 1 {
                 let delivered = check_construction(t) || check_building(t);
                 if !delivered {
-                    let cells = &self.cells;
+                    let tiles = &self.tiles;
                     let return_path = find_multipath(
                         std::iter::once(t.dest),
                         |pos| pos == t.src,
                         |from_direction, pos| {
-                            let cell = &cells[pos];
+                            let cell = &tiles[pos];
                             if let Some(from_direction) = from_direction {
                                 matches!(cell.conveyor, Conveyor::One(_, dir) if dir == from_direction)
                                     && cell.conveyor.is_some()

--- a/game-logic/src/transport.rs
+++ b/game-logic/src/transport.rs
@@ -4,7 +4,7 @@ use std::{
     hash::Hash,
 };
 
-use crate::{task::Direction, AsteroidColoniesGame, Conveyor, ItemType, Pos, WIDTH};
+use crate::{task::Direction, AsteroidColoniesGame, Conveyor, ItemType, Pos};
 
 /// Transporting item
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/game-logic/src/transport.rs
+++ b/game-logic/src/transport.rs
@@ -77,12 +77,12 @@ impl AsteroidColoniesGame {
                         std::iter::once(t.dest),
                         |pos| pos == t.src,
                         |from_direction, pos| {
-                            let cell = &tiles[pos];
+                            let tile = &tiles[pos];
                             if let Some(from_direction) = from_direction {
-                                matches!(cell.conveyor, Conveyor::One(_, dir) if dir == from_direction)
-                                    && cell.conveyor.is_some()
+                                matches!(tile.conveyor, Conveyor::One(_, dir) if dir == from_direction)
+                                    && tile.conveyor.is_some()
                             } else {
-                                cell.conveyor.is_some()
+                                tile.conveyor.is_some()
                             }
                         },
                     );

--- a/js/main.js
+++ b/js/main.js
@@ -30,6 +30,7 @@ const syncPeriod = SYNC_PERIOD;
 const port = 3883;
 let websocket = null;
 let sessionId = null;
+let debugDrawChunks = false;
 
 (async () => {
     const wasm = await import("../wasm/Cargo.toml");
@@ -290,6 +291,15 @@ let sessionId = null;
             }
         }
     })
+
+    document.body.addEventListener("keydown", evt => {
+        switch (evt.code) {
+            case "KeyD":
+                debugDrawChunks = !debugDrawChunks;
+                game.set_debug_draw_chunks(debugDrawChunks);
+                break;
+        }
+    });
 
     function enterConveyorEdit() {
         const buildMenuElem = document.getElementById("buildMenu");

--- a/js/main.js
+++ b/js/main.js
@@ -348,6 +348,7 @@ let sessionId = null;
                 if (event.data instanceof ArrayBuffer) {
                     const byteArray = new Uint8Array(event.data);
                     game.deserialize_bin(byteArray);
+                    postChunksDigest();
                 }
                 else {
                 // console.log(`Event through WebSocket: ${event.data}`);
@@ -355,6 +356,7 @@ let sessionId = null;
                     if(data.type === "clientUpdate"){
                         if(game){
                             game.deserialize(data.payload);
+                            postChunksDigest();
                         }
                         // const payload = data.payload;
                         // const body = CelestialBody.celestialBodies.get(payload.bodyState.name);
@@ -364,6 +366,7 @@ let sessionId = null;
                     }
                 }
             });
+            websocket.addEventListener("open", postChunksDigest);
         }
     }
 
@@ -375,6 +378,12 @@ let sessionId = null;
             type,
             payload
         }));
+    }
+
+    function postChunksDigest() {
+        game.uniformify_tiles();
+        const chunksDigest = game.serialize_chunks_digest();
+        websocket.send(JSON.stringify({type: "ChunksDigest", payload: {chunks_digest: chunksDigest}}));
     }
 })()
 

--- a/js/main.js
+++ b/js/main.js
@@ -383,7 +383,8 @@ let sessionId = null;
     function postChunksDigest() {
         game.uniformify_tiles();
         const chunksDigest = game.serialize_chunks_digest();
-        websocket.send(JSON.stringify({type: "ChunksDigest", payload: {chunks_digest: chunksDigest}}));
+        // websocket.send(JSON.stringify({type: "ChunksDigest", payload: {chunks_digest: chunksDigest}}));
+        websocket.send(chunksDigest);
     }
 })()
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.114"
 rand = "0.8.5"
 anyhow = "1.0.80"
+bincode = "1.3.3"
 
 [package.metadata.deb]
 assets = [

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -200,7 +200,7 @@ async fn main() -> std::io::Result<()> {
         } else {
             eprintln!(
                 "Deserialized data {} object in {}ms",
-                game.iter_cell().count(),
+                game.count_tiles(),
                 start.elapsed().as_micros() as f64 * 1e-3
             );
         }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -23,7 +23,7 @@ use std::{
     sync::{Mutex, RwLock},
     time::Instant,
 };
-use websocket::{websocket_index, NotifyState, NotifyStateEnum, SetStateBinWs};
+use websocket::{websocket_index, NotifyState, NotifyStateEnum};
 
 type Game = AsteroidColoniesGame;
 
@@ -257,12 +257,16 @@ async fn main() -> std::io::Result<()> {
                 //         set_state: NotifyStateEnum::SetState(SetStateWs(serialized)),
                 //     });
                 // }
-                if let Ok(serialized) = game.serialize_bin() {
-                    data_copy.srv.do_send(NotifyState {
-                        session_id: None,
-                        set_state: NotifyStateEnum::SetStateBin(SetStateBinWs(serialized)),
-                    });
-                }
+                // if let Ok(serialized) = game.serialize_bin() {
+                //     data_copy.srv.do_send(NotifyState {
+                //         session_id: None,
+                //         set_state: NotifyStateEnum::SetStateBin(SetStateBinWs(serialized)),
+                //     });
+                // }
+                data_copy.srv.do_send(NotifyState {
+                    session_id: None,
+                    set_state: NotifyStateEnum::SetStateWithDiff,
+                });
                 *last_pushed = Instant::now();
             }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -238,6 +238,7 @@ async fn main() -> std::io::Result<()> {
 
             let mut last_saved = data_copy.last_saved.lock().unwrap();
             if autosave_period_s < last_saved.elapsed().as_secs_f64() {
+                game.uniformify_tiles();
                 if let Ok(serialized) = serialize_state(&game, autosave_pretty) {
                     let autosave_file = data_copy.autosave_file.clone();
                     actix_web::rt::spawn(async move {
@@ -249,6 +250,7 @@ async fn main() -> std::io::Result<()> {
 
             let mut last_pushed = data_copy.last_pushed.lock().unwrap();
             if push_period_s < last_pushed.elapsed().as_secs_f64() {
+                game.uniformify_tiles();
                 // if let Ok(serialized) = serialize_state(&game, false) {
                 //     data_copy.srv.do_send(NotifyState {
                 //         session_id: None,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -303,8 +303,9 @@ async fn main() -> std::io::Result<()> {
     .run()
     .await;
 
-    if let Ok(serialized) = serialize_state(&data_copy2.game.read().unwrap(), autosave_pretty) {
-        save_file(&data_copy2.autosave_file, &serialized);
+    match serialize_state(&data_copy2.game.read().unwrap(), autosave_pretty) {
+        Ok(serialized) => save_file(&data_copy2.autosave_file, &serialized),
+        Err(e) => println!("Error saving file: {e}"),
     }
     Ok(())
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -30,6 +30,7 @@ pub struct Connect {
 pub enum Message {
     Text(String),
     Bin(Vec<u8>),
+    StateWithDiff,
 }
 
 // const CHAT_HISTORY_MAX: usize = 100;
@@ -96,6 +97,14 @@ impl ChatServer {
             }
         }
     }
+
+    fn send_message_with_diff(&self, skip_id: Option<SessionId>) {
+        for (i, addr) in &self.sessions {
+            if Some(*i) != skip_id {
+                let _ = addr.do_send(Message::StateWithDiff);
+            }
+        }
+    }
 }
 
 /// Make actor from `ChatServer`
@@ -149,6 +158,7 @@ impl Handler<NotifyState> for ChatServer {
                 self.send_message(&serde_json::to_string(&payload).unwrap(), session_id);
             }
             NotifyStateEnum::SetStateBin(msg) => self.send_message_bin(&msg.0, session_id),
+            NotifyStateEnum::SetStateWithDiff => self.send_message_with_diff(session_id),
         }
     }
 }

--- a/server/src/websocket.rs
+++ b/server/src/websocket.rs
@@ -210,7 +210,11 @@ impl StreamHandler<WsResult> for SessionWs {
                     ));
                 }
             }
-            Ok(ws::Message::Binary(bin)) => ctx.binary(bin),
+            Ok(ws::Message::Binary(bin)) => {
+                if let Ok(chunks_digest) = bincode::deserialize(&bin) {
+                    self.chunks_digest = chunks_digest;
+                }
+            }
             _ => (),
         }
     }

--- a/server/src/websocket.rs
+++ b/server/src/websocket.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{
     server::ChatServer,
     server::{Connect, Message},
@@ -11,7 +13,7 @@ use ::serde::{Deserialize, Serialize};
 use actix_web_actors::ws;
 use asteroid_colonies_logic::{
     construction::{Construction, ConstructionType},
-    Pos,
+    Pos, Position,
 };
 
 /// Open a WebSocket instance and give it to the client.
@@ -29,6 +31,7 @@ pub(crate) async fn websocket_index(
         data: data.clone(),
         session_id,
         addr: data.srv.clone(),
+        chunks_digest: HashMap::new(),
     };
 
     // let srv = data.srv.clone();
@@ -47,6 +50,7 @@ struct SessionWs {
     pub data: web::Data<ServerData>,
     pub session_id: SessionId,
     pub addr: Addr<ChatServer>,
+    pub chunks_digest: HashMap<Position, u64>,
 }
 
 impl Actor for SessionWs {
@@ -92,6 +96,13 @@ impl Handler<Message> for SessionWs {
         match msg {
             Message::Text(txt) => ctx.text(txt),
             Message::Bin(bin) => ctx.binary(bin),
+            Message::StateWithDiff => {
+                let game = self.data.game.read().unwrap();
+                match game.serialize_with_diffs(&self.chunks_digest) {
+                    Ok(bytes) => ctx.binary(bytes),
+                    Err(e) => ctx.text(format!("Error: {e}")),
+                }
+            }
         }
     }
 }
@@ -118,6 +129,7 @@ impl std::fmt::Debug for SetStateBinWs {
 pub(crate) enum NotifyStateEnum {
     SetState(SetStateWs),
     SetStateBin(SetStateBinWs),
+    SetStateWithDiff,
 }
 
 #[derive(Deserialize, Serialize, Debug, Message)]
@@ -172,6 +184,11 @@ enum WsMessage {
         pos: Pos,
         name: String,
     },
+    ChunksDigest {
+        // The payload represents HashMap<Position, u64>, but we do not deserialize into JSON for
+        // performance reasons.
+        chunks_digest: String,
+    },
 }
 
 impl StreamHandler<WsResult> for SessionWs {
@@ -179,7 +196,7 @@ impl StreamHandler<WsResult> for SessionWs {
         match msg {
             Ok(ws::Message::Ping(msg)) => ctx.pong(&msg),
             Ok(ws::Message::Text(text)) => {
-                println!("received ws text: {text}");
+                println!("client received ws text: {text}");
                 let payload: WsMessage = if let Ok(payload) = serde_json::from_str(&text) {
                     payload
                 } else {
@@ -235,6 +252,9 @@ impl SessionWs {
             WsMessage::SetRecipe { pos, name } => {
                 game.set_recipe(pos[0], pos[1], &name)
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
+            }
+            WsMessage::ChunksDigest { chunks_digest } => {
+                self.chunks_digest = serde_json::from_str(&chunks_digest)?;
             }
         }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -213,7 +213,7 @@ impl AsteroidColonies {
         self.game.uniformify_tiles();
     }
 
-    pub fn serialize_chunks_digest(&self) -> Result<String, JsValue> {
+    pub fn serialize_chunks_digest(&self) -> Result<Vec<u8>, JsValue> {
         self.game
             .serialize_chunks_digest()
             .map_err(|e| JsValue::from(e.to_string()))

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -107,7 +107,7 @@ impl AsteroidColonies {
         let ix = (x - self.viewport.offset[0]).div_euclid(TILE_SIZE) as i32;
         let iy = (y - self.viewport.offset[1]).div_euclid(TILE_SIZE) as i32;
         if ix < 0 || WIDTH as i32 <= ix || iy < 0 || HEIGHT as i32 <= iy {
-            return Err(JsValue::from("Point outside cell"));
+            return Err(JsValue::from("Point outside tile"));
         }
         let res = match com {
             "excavate" => self.game.excavate(ix, iy),

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -63,6 +63,7 @@ pub struct AsteroidColonies {
     cursor: Option<Pos>,
     assets: Assets,
     viewport: Viewport,
+    debug_draw_chunks: bool,
 }
 
 #[wasm_bindgen]
@@ -84,6 +85,7 @@ impl AsteroidColonies {
                 ],
                 size: [vp_width, vp_height],
             },
+            debug_draw_chunks: false,
         })
     }
 
@@ -188,6 +190,10 @@ impl AsteroidColonies {
 
     pub fn tick(&mut self) -> Result<(), JsValue> {
         self.game.tick().map_err(JsValue::from)
+    }
+
+    pub fn set_debug_draw_chunks(&mut self, v: bool) {
+        self.debug_draw_chunks = v;
     }
 
     pub fn get_build_menu(&self) -> Result<Vec<JsValue>, JsValue> {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -208,4 +208,14 @@ impl AsteroidColonies {
             .deserialize_bin(data)
             .map_err(|e| JsValue::from(format!("{e}")))
     }
+
+    pub fn uniformify_tiles(&mut self) {
+        self.game.uniformify_tiles();
+    }
+
+    pub fn serialize_chunks_digest(&self) -> Result<String, JsValue> {
+        self.game
+            .serialize_chunks_digest()
+            .map_err(|e| JsValue::from(e.to_string()))
+    }
 }

--- a/wasm/src/render.rs
+++ b/wasm/src/render.rs
@@ -10,7 +10,7 @@ use asteroid_colonies_logic::{
     task::{
         Direction, GlobalTask, Task, EXCAVATE_TIME, LABOR_EXCAVATE_TIME, MOVE_ITEM_TIME, MOVE_TIME,
     },
-    Cell, CellState, ItemType, HEIGHT, WIDTH,
+    ItemType, Tile, TileState, HEIGHT, WIDTH,
 };
 
 pub(crate) const TILE_SIZE: f64 = 32.;
@@ -120,7 +120,7 @@ impl AsteroidColonies {
             Ok(())
         };
 
-        let mut rendered_cells = 0;
+        let mut rendered_tiles = 0;
         let mut render_cell = |ix: i32, iy: i32| -> Result<(), JsValue> {
             let y = iy as f64 * TILE_SIZE + offset[1];
             let x = ix as f64 * TILE_SIZE + offset[0];
@@ -137,14 +137,14 @@ impl AsteroidColonies {
                         TILE_SIZE,
                         TILE_SIZE,
                     )?;
-                rendered_cells += 1;
+                rendered_tiles += 1;
                 return Ok(());
             }
             let cell = &self.game.cell_at([ix, iy]);
             let (sx, sy) = match cell.state {
-                CellState::Empty => (0., TILE_SIZE),
-                CellState::Solid => (0., 0.),
-                CellState::Space => (0., 2. * TILE_SIZE),
+                TileState::Empty => (0., TILE_SIZE),
+                TileState::Solid => (0., 0.),
+                TileState::Space => (0., 2. * TILE_SIZE),
             };
             context.draw_image_with_html_image_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
                 &self.assets.img_bg,
@@ -190,7 +190,7 @@ impl AsteroidColonies {
                         TILE_SIZE / 2.,
                         TILE_SIZE / 2.,
                     )?;
-                rendered_cells += 1;
+                rendered_tiles += 1;
                 Ok(())
             };
 
@@ -211,7 +211,7 @@ impl AsteroidColonies {
                 render_power_grid(context, x, y)?;
             }
             render_conveyor(context, x, y, cell.conveyor)?;
-            rendered_cells += 1;
+            rendered_tiles += 1;
             Ok(())
         };
 
@@ -224,7 +224,7 @@ impl AsteroidColonies {
                 render_cell(ix, iy)?;
             }
         }
-        // console_log!("rendered_cells: {}", rendered_cells);
+        // console_log!("rendered_tiles: {}", rendered_tiles);
 
         let time = self.game.get_global_time();
 
@@ -494,12 +494,12 @@ impl<'a> RenderBar<'a> {
 }
 
 #[allow(clippy::many_single_char_names)]
-pub(crate) fn calculate_back_image(ret: &mut [Cell]) {
+pub(crate) fn calculate_back_image(ret: &mut [Tile]) {
     for uy in 0..HEIGHT {
         let y = uy as i32;
         for ux in 0..WIDTH {
             let x = ux as i32;
-            if !matches!(ret[(ux + uy * WIDTH) as usize].state, CellState::Solid) {
+            if !matches!(ret[(ux + uy * WIDTH) as usize].state, TileState::Solid) {
                 let cell = &mut ret[(ux + uy * WIDTH) as usize];
                 cell.image_lt = 0;
                 cell.image_lb = 0;
@@ -513,8 +513,8 @@ pub(crate) fn calculate_back_image(ret: &mut [Cell]) {
                 } else {
                     let state = ret[x as usize + y as usize * WIDTH].state;
                     (
-                        !matches!(state, CellState::Solid) as u8,
-                        matches!(state, CellState::Space) as u8,
+                        !matches!(state, TileState::Solid) as u8,
+                        matches!(state, TileState::Space) as u8,
                     )
                 }
             };

--- a/wasm/src/render.rs
+++ b/wasm/src/render.rs
@@ -16,7 +16,7 @@ use asteroid_colonies_logic::{
     task::{
         Direction, GlobalTask, Task, EXCAVATE_TIME, LABOR_EXCAVATE_TIME, MOVE_ITEM_TIME, MOVE_TIME,
     },
-    Chunk, ImageIdx, ItemType, Position, TileState, Tiles, CHUNK_SIZE, HEIGHT, WIDTH,
+    Chunk, ImageIdx, ItemType, Position, TileState, Tiles, CHUNK_SIZE,
 };
 
 pub(crate) const TILE_SIZE: f64 = 32.;
@@ -130,22 +130,6 @@ impl AsteroidColonies {
         let mut render_tile = |ix: i32, iy: i32| -> Result<(), JsValue> {
             let y = iy as f64 * TILE_SIZE + offset[1];
             let x = ix as f64 * TILE_SIZE + offset[0];
-            if ix < 0 || (WIDTH as i32) <= ix || iy < 0 || (HEIGHT as i32) <= iy {
-                context
-                    .draw_image_with_html_image_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
-                        &self.assets.img_bg,
-                        0.,
-                        2. * TILE_SIZE,
-                        TILE_SIZE,
-                        TILE_SIZE,
-                        x,
-                        y,
-                        TILE_SIZE,
-                        TILE_SIZE,
-                    )?;
-                rendered_tiles += 1;
-                return Ok(());
-            }
             let tile = &self.game.tile_at([ix, iy]);
             let (sx, sy) = match tile.state {
                 TileState::Empty => (0., TILE_SIZE),

--- a/wasm/src/render.rs
+++ b/wasm/src/render.rs
@@ -552,28 +552,30 @@ pub(crate) fn calculate_back_image(tiles: &mut Tiles) {
 
 const CHUNK_SIZE_I: i32 = CHUNK_SIZE as i32;
 
+/// Determine if the chunk designated by `pos` has an edge that is adjacent to a non-solid edge.
+/// It is necessary to non-uniformify this chunk if this function returns true.
 fn has_edge(tiles: &Tiles, pos: &Position) -> bool {
     for x in -1..=CHUNK_SIZE_I {
         let top = [x + pos.x * CHUNK_SIZE_I, pos.y * CHUNK_SIZE_I];
         let beyond_top = [x + pos.x * CHUNK_SIZE_I, pos.y * CHUNK_SIZE_I - 1];
-        if tiles[top] != tiles[beyond_top] {
+        if tiles[top].state != tiles[beyond_top].state {
             return true;
         }
         let bottom = [x + pos.x * CHUNK_SIZE_I, (pos.y + 1) * CHUNK_SIZE_I - 1];
         let beyond_bottom = [x + pos.x * CHUNK_SIZE_I, (pos.y + 1) * CHUNK_SIZE_I];
-        if tiles[bottom] != tiles[beyond_bottom] {
+        if tiles[bottom].state != tiles[beyond_bottom].state {
             return true;
         }
     }
     for y in -1..=CHUNK_SIZE_I {
         let left = [pos.x * CHUNK_SIZE_I, y + pos.y * CHUNK_SIZE_I];
         let beyond_left = [pos.x * CHUNK_SIZE_I - 1, y + pos.y * CHUNK_SIZE_I];
-        if tiles[left] != tiles[beyond_left] {
+        if tiles[left].state != tiles[beyond_left].state {
             return true;
         }
         let right = [(pos.x + 1) * CHUNK_SIZE_I - 1, y + pos.y * CHUNK_SIZE_I];
         let beyond_bottom = [(pos.x + 1) * CHUNK_SIZE_I, y + pos.y * CHUNK_SIZE_I];
-        if tiles[right] != tiles[beyond_bottom] {
+        if tiles[right].state != tiles[beyond_bottom].state {
             return true;
         }
     }

--- a/wasm/src/render.rs
+++ b/wasm/src/render.rs
@@ -434,6 +434,19 @@ impl AsteroidColonies {
             }
         }
 
+        if self.debug_draw_chunks {
+            const CHUNK_TILE_SIZE: f64 = CHUNK_SIZE as f64 * TILE_SIZE;
+            for (pos, chunk) in self.game.tiles().chunks() {
+                let x = pos.x as f64 * CHUNK_TILE_SIZE + offset[0] + 2.;
+                let y = pos.y as f64 * CHUNK_TILE_SIZE + offset[1] + 2.;
+                context.set_stroke_style(&JsValue::from(match chunk {
+                    Chunk::Tiles(_, _) => "#f00",
+                    Chunk::Uniform(_, _) => "#0f0",
+                }));
+                context.stroke_rect(x, y, CHUNK_TILE_SIZE - 4., CHUNK_TILE_SIZE - 4.);
+            }
+        }
+
         if let Some(cursor) = self.cursor {
             let img = &self.assets.img_cursor;
             let x = cursor[0] as f64 * TILE_SIZE + offset[0];


### PR DESCRIPTION
# The problem

The map data is stored in a `Vec<Cell>`, which has a fixed `WIDTH` and `HEIGHT`.
This design poses 2 major disadvantages.

* It is not expandable; the map size has to be fixed first and cannot change afterwards.
* In order to synchronize the map between the server and the client, you need to serialize the whole map, but most of the map is not going to change.

We waste a lot of bandwidth by requiring to send the whole game state for every synchronization.

Actually, the data transferred for each synchronization is not too big. The default map is about 90kB with bincode.
We also don't apply compression.
Below is a recording of the communication between the server and the client on a websocket.

![image](https://github.com/msakuta/asteroid-colonies/assets/2798715/c9101c37-550b-41d7-8a70-d2f861080393)

However, if we expand our game and put more info and synchronize frequenty, this size will increase (for example, we plan to add ore distribution to the tiles).
We want to implement a framework to avoid this as soon as possible.


# The solution

We split the map into chunks and send only changed chunks to greatly reduce the bandwidth.
This is a special case of more general idea of partial state update.
Partial state update should be applicable not only to tiles but also any kind of objects, but we want to pick the low hanging fruit first.

A Chunk is a bunch of Tiles in a square of fixed size, defined by `TILE_SIZE`, whose default is 16.
This is a design inspired by Factorio and also implemented in [FactorishWasm's PR](https://github.com/msakuta/FactorishWasm/pull/17), in order to achieve infinite procedurally-generated world.

A Chunk is an enum like below, either tiles (a vector of each tile in the chunk) or a Uniform variant (which indicates the chunk is made of uniform Tile, so that we can compress it with a single copy of a Tile).
It can be thought of a simplified run-length encoding.

```rust
pub enum Chunk {
    Tiles(Vec<Tile>, u64),
    Uniform(Tile, u64),
}
```

The whole data structure (`Tiles`) is defined as below.
`Position` is an index into the HashMap that indicates the position of the chunk.

```rust
pub struct Tiles {
    pub(crate) chunks: HashMap<Position, Chunk>,
}
```

## Uniformify

We need to check if the tiles in a chunk uniform and replace it with `Uniform` variant, but we do not want this check too frequenty, since the map won't change often.
We call this process "uniformify" and defined as a method of `Tiles`.

## Sending chunks digest

The client sends its local chunks status with hashes.
The server sends only chunks with different hashes from the client.
In this way, server sends much less data from before, as long as most of the map stays the same.

The effect is remarkable; the server only needs about 400 bytes to synchronize state (most of the data is now objects like buildings, items and crews), which is 1/20 reduction.
In exchange, the client has to send its hashes periodically.

We store the hashes of each chunk in a structure like below and serialize into bincode.

```rust
HashMap<Position, u64>
```

## Pitfalls in making chunks digest

I have encountered few pitfalls in making chunks digest.

First, Rust's `DefaultHasher` (SipHash2-4) is _not reproducible_, for security reasons. It is randomized for each instance.
We want to use the digest to check the same chunks, so we need a reproducible hash function among the server and the client.
For this, we use [FNV hash](https://github.com/servo/rust-fnv). It is very fast, compact and high quality hash, but not cryptographycally secure. We do not need cryptographical security in this digest, because it's not part of secure data validation. It's just an optimization to send little amount of data.

Second, the hash value of `usize` may be different among CPU architectures.
It means x64 and Wasm32 are not compatible.
Enum values are also not compatible, probably because hash implementation tries to cast it to usize first.
We need to implement custom hash functions for these types to avoid incompatibilities like below.

```rust
impl Hash for TileState {
    fn hash<H: Hasher>(&self, state: &mut H) {
        ((*self) as u8).hash(state)
    }
}
```




## Communication flow

Now that the server and the client have to exchange states to each other for the optimal synchronization, we have a new flow.

* The client sends chunks digest to the server
* The server stores the last sent client chunks digest
* When the server hits periodic update, it compares the clients' chunks digest and send only changed parts to each client
* The client receives the data and only update chunks that are included in the data

You may notice that there is a chance that the client may develop the map state (in its own simulation) and may have the same state as the server (predicted changes), but it is relatively rare and we can ignore the overhead.

Below is a recording of the communication between the server and the client on a websocket.

![image](https://github.com/msakuta/asteroid-colonies/assets/2798715/32b3668a-2f0c-466a-9720-9fa2ffab10c2)
