### PR TITLE
Use Entity system

### DIFF
--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -198,7 +198,7 @@ impl Building {
         bldgs: &EntitySet<Building>,
         tiles: &Tiles,
         transports: &mut EntitySet<Transport>,
-        constructions: &mut [Construction],
+        constructions: &mut EntitySet<Construction>,
         crews: &mut EntitySet<Crew>,
         gtasks: &[GlobalTask],
         rng: &mut Xor128,
@@ -290,7 +290,7 @@ impl Building {
                     }
                     r
                 }
-                for construction in constructions {
+                for construction in constructions.iter() {
                     let pos = construction.pos;
                     if !matches!(tiles[pos].state, TileState::Empty) {
                         // Don't bother trying to find a path in an unreachable area.
@@ -303,16 +303,16 @@ impl Building {
                         tiles,
                     };
                     let crew = print_time("try_find_deliver", || {
-                        this.try_find_deliver(id, construction, &envs)
+                        this.try_find_deliver(id, &*construction, &envs)
                     })
                     .or_else(|| {
                         print_time("try_find_pickup_and_deliver", || {
-                            this.try_find_pickup_and_deliver(id, construction, &envs)
+                            this.try_find_pickup_and_deliver(id, &*construction, &envs)
                         })
                     })
                     .or_else(|| {
                         print_time("try_send_to_build", || {
-                            this.try_send_to_build(id, construction, &envs)
+                            this.try_send_to_build(id, &*construction, &envs)
                         })
                     });
                     if let Some(crew) = crew {

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -171,9 +171,9 @@ impl Building {
     pub fn intersects(&self, pos: Pos) -> bool {
         let size = self.type_.size();
         self.pos[0] <= pos[0]
-            && pos[0] <= self.pos[0] + size[0] as i32
+            && pos[0] < self.pos[0] + size[0] as i32
             && self.pos[1] <= pos[1]
-            && pos[1] <= self.pos[1] + size[1] as i32
+            && pos[1] < self.pos[1] + size[1] as i32
     }
 
     pub fn intersects_rect(&self, pos: Pos, other_size: [usize; 2]) -> bool {

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -176,6 +176,14 @@ impl Building {
             && pos[1] <= self.pos[1] + size[1] as i32
     }
 
+    pub(super) fn set_recipe(&mut self, recipe: Option<&Recipe>) -> Result<(), String> {
+        if !matches!(self.type_, BuildingType::Assembler) {
+            return Err(String::from("The building is not an assembler"));
+        }
+        self.recipe = recipe.cloned();
+        Ok(())
+    }
+
     pub fn tick(
         bldgs: &EntitySet<Building>,
         idx: usize,

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -182,7 +182,7 @@ impl Building {
         tiles: &Tiles,
         transports: &mut EntitySet<Transport>,
         constructions: &mut [Construction],
-        crews: &mut Vec<Crew>,
+        crews: &mut EntitySet<Crew>,
         gtasks: &[GlobalTask],
         rng: &mut Xor128,
     ) -> Result<(), String> {
@@ -264,7 +264,7 @@ impl Building {
                         continue;
                     }
                     if let Some(crew) = Crew::new_task(this.pos, gtask, tiles) {
-                        crews.push(crew);
+                        crews.insert(crew);
                         this.crews -= 1;
                         return Ok(());
                     }
@@ -302,7 +302,7 @@ impl Building {
                         })
                     });
                     if let Some(crew) = crew {
-                        crews.push(crew);
+                        crews.insert(crew);
                         this.crews -= 1;
                         return Ok(());
                     }

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -12,7 +12,7 @@ use self::crew_cabin::Envs;
 use crate::{
     construction::Construction,
     crew::expected_crew_pickup_any,
-    entity::{EntityEntry, EntityIterExt, EntityIterMutExt},
+    entity::{EntityEntry, EntityIterExt, EntityIterMutExt, EntitySet},
     hash_map,
     items::ItemType,
     measure_time,
@@ -167,7 +167,7 @@ impl Building {
         bldgs: &mut [EntityEntry<Building>],
         idx: usize,
         tiles: &Tiles,
-        transports: &mut Vec<Transport>,
+        transports: &mut EntitySet<Transport>,
         constructions: &mut [Construction],
         crews: &mut Vec<Crew>,
         gtasks: &[GlobalTask],

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -176,6 +176,14 @@ impl Building {
             && pos[1] <= self.pos[1] + size[1] as i32
     }
 
+    pub fn intersects_rect(&self, pos: Pos, other_size: [usize; 2]) -> bool {
+        let size = self.type_.size();
+        self.pos[0] < pos[0] + other_size[0] as i32
+            && pos[0] < self.pos[0] + size[0] as i32
+            && self.pos[1] < pos[1] + other_size[1] as i32
+            && pos[1] < self.pos[1] + size[1] as i32
+    }
+
     pub(super) fn set_recipe(&mut self, recipe: Option<&Recipe>) -> Result<(), String> {
         if !matches!(self.type_, BuildingType::Assembler) {
             return Err(String::from("The building is not an assembler"));

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -277,7 +277,7 @@ impl Building {
                     if crews.iter().any(|crew| crew.target() == Some(*goal_pos)) {
                         continue;
                     }
-                    if let Some(crew) = Crew::new_task(id, gtask, tiles, bldgs) {
+                    if let Some(crew) = Crew::new_task(id, this, gtask, tiles) {
                         crews.insert(crew);
                         this.crews -= 1;
                         return Ok(());

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -240,7 +240,7 @@ impl Building {
                         }
                         GlobalTask::Cleanup(pos) => {
                             let pickups = expected_crew_pickup_any(crews, *pos);
-                            if pickups == 0 {
+                            if pickups != 0 {
                                 continue;
                             }
                             pos

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -1,9 +1,13 @@
+mod crew_cabin;
+
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
 };
 
 use ::serde::{Deserialize, Serialize};
+
+use self::crew_cabin::Envs;
 
 use crate::{
     construction::Construction,
@@ -268,7 +272,8 @@ impl Building {
                         crews,
                         tiles,
                     };
-                    let crew = try_find_deliver(this, construction, &envs)
+                    let crew = this
+                        .try_find_deliver(construction, &envs)
                         .or_else(|| {
                             construction.extra_ingredients().find_map(|(ty, _)| {
                                 let path_to_dest = find_multipath(
@@ -359,54 +364,6 @@ impl Building {
         }
         Ok(())
     }
-}
-
-struct Envs<'a> {
-    first: &'a [EntityEntry<Building>],
-    last: &'a [EntityEntry<Building>],
-    transports: &'a [Transport],
-    crews: &'a [Crew],
-    tiles: &'a Tiles,
-}
-
-fn try_find_deliver(this: &mut Building, construction: &Construction, envs: &Envs) -> Option<Crew> {
-    construction
-        .required_ingredients(envs.transports, envs.crews)
-        .find_map(|(ty, _)| {
-            this.inventory
-                .get_mut(&ty)
-                .and_then(|n| {
-                    if 0 < *n {
-                        println!("new_deliver, sending a crew {:?}", construction.pos);
-                        *n -= 1;
-                        Crew::new_deliver(this.pos, construction.pos, ty, &envs.tiles)
-                    } else {
-                        None
-                    }
-                })
-                .or_else(|| {
-                    let path_to_source = find_multipath(
-                        [this.pos].into_iter(),
-                        |pos| {
-                            envs.first.iter().chain(envs.last.iter()).any(|o| {
-                                o.payload
-                                    .as_ref()
-                                    .map(|o| {
-                                        o.pos == pos
-                                            && 0 < o.inventory.get(&ty).copied().unwrap_or(0)
-                                    })
-                                    .unwrap_or(false)
-                            })
-                        },
-                        |_, pos| matches!(envs.tiles[pos].state, TileState::Empty),
-                    );
-                    path_to_source
-                        .and_then(|src| src.first().copied())
-                        .and_then(|src| {
-                            Crew::new_pickup(this.pos, src, construction.pos, ty, envs.tiles)
-                        })
-                })
-        })
 }
 
 impl AsteroidColoniesGame {

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -14,7 +14,7 @@ use crate::{
     crew::expected_crew_pickup_any,
     entity::{EntityId, EntitySet},
     hash_map,
-    items::ItemType,
+    items::{Inventory, ItemType},
     measure_time,
     push_pull::{pull_inputs, push_outputs},
     task::{GlobalTask, Task, RAW_ORE_SMELT_TIME},
@@ -110,7 +110,7 @@ pub struct Building {
     pub pos: [i32; 2],
     pub type_: BuildingType,
     pub task: Task,
-    pub inventory: HashMap<ItemType, usize>,
+    pub inventory: Inventory,
     /// The number of crews attending this building.
     pub crews: usize,
     // TODO: We want to avoid copies of recipes, but deserializing a recipe with static is
@@ -129,7 +129,7 @@ impl Building {
             pos,
             type_,
             task: Task::None,
-            inventory: HashMap::new(),
+            inventory: Inventory::new(),
             crews: type_.max_crews(),
             recipe: None,
             direction: None,
@@ -137,11 +137,7 @@ impl Building {
         }
     }
 
-    pub fn new_inventory(
-        pos: [i32; 2],
-        type_: BuildingType,
-        inventory: HashMap<ItemType, usize>,
-    ) -> Self {
+    pub fn new_inventory(pos: [i32; 2], type_: BuildingType, inventory: Inventory) -> Self {
         Self {
             pos,
             type_,

--- a/game-logic/src/building/crew_cabin.rs
+++ b/game-logic/src/building/crew_cabin.rs
@@ -26,7 +26,6 @@ impl Building {
                     .get_mut(&ty)
                     .and_then(|n| {
                         if 0 < *n {
-                            println!("new_deliver, sending a crew {:?}", construction.pos);
                             *n -= 1;
                             Crew::new_deliver(self.pos, construction.pos, ty, &envs.tiles)
                         } else {
@@ -56,5 +55,49 @@ impl Building {
                             })
                     })
             })
+    }
+
+    pub(super) fn try_find_pickup_and_deliver(
+        &mut self,
+        construction: &Construction,
+        envs: &Envs,
+    ) -> Option<Crew> {
+        construction.extra_ingredients().find_map(|(ty, _)| {
+            let path_to_dest = find_multipath(
+                [construction.pos].into_iter(),
+                |pos| {
+                    envs.first.iter().chain(envs.last.iter()).any(|o| {
+                        o.payload
+                            .as_ref()
+                            .map(|o| o.pos == pos && o.inventory_size() < o.type_.capacity())
+                            .unwrap_or(false)
+                    })
+                },
+                |_, pos| matches!(envs.tiles[pos].state, TileState::Empty),
+            );
+
+            path_to_dest
+                .and_then(|dst| dst.first().copied())
+                .and_then(|dst| Crew::new_pickup(self.pos, construction.pos, dst, ty, envs.tiles))
+        })
+    }
+
+    pub(super) fn try_send_to_build(
+        &mut self,
+        construction: &Construction,
+        envs: &Envs,
+    ) -> Option<Crew> {
+        if envs
+            .crews
+            .iter()
+            .any(|crew| crew.target() == Some(construction.pos))
+        {
+            return None;
+        }
+        if construction.ingredients_satisfied() {
+            Crew::new_build(self.pos, construction.pos, envs.tiles)
+        } else {
+            None
+        }
     }
 }

--- a/game-logic/src/building/crew_cabin.rs
+++ b/game-logic/src/building/crew_cabin.rs
@@ -1,6 +1,6 @@
 use crate::{
     construction::Construction,
-    entity::{EntityEntry, EntityIterExt},
+    entity::{EntityEntry, EntityIterExt, EntitySet},
     push_pull::HasInventory,
     transport::find_multipath,
     Crew, TileState, Tiles, Transport,
@@ -11,7 +11,7 @@ use super::Building;
 pub(super) struct Envs<'a> {
     pub first: &'a [EntityEntry<Building>],
     pub last: &'a [EntityEntry<Building>],
-    pub transports: &'a [Transport],
+    pub transports: &'a EntitySet<Transport>,
     pub crews: &'a [Crew],
     pub tiles: &'a Tiles,
 }

--- a/game-logic/src/building/crew_cabin.rs
+++ b/game-logic/src/building/crew_cabin.rs
@@ -1,0 +1,60 @@
+use crate::{
+    construction::Construction, entity::EntityEntry, transport::find_multipath, Crew, TileState,
+    Tiles, Transport,
+};
+
+use super::Building;
+
+pub(super) struct Envs<'a> {
+    pub first: &'a [EntityEntry<Building>],
+    pub last: &'a [EntityEntry<Building>],
+    pub transports: &'a [Transport],
+    pub crews: &'a [Crew],
+    pub tiles: &'a Tiles,
+}
+
+impl Building {
+    pub(super) fn try_find_deliver(
+        &mut self,
+        construction: &Construction,
+        envs: &Envs,
+    ) -> Option<Crew> {
+        construction
+            .required_ingredients(envs.transports, envs.crews)
+            .find_map(|(ty, _)| {
+                self.inventory
+                    .get_mut(&ty)
+                    .and_then(|n| {
+                        if 0 < *n {
+                            println!("new_deliver, sending a crew {:?}", construction.pos);
+                            *n -= 1;
+                            Crew::new_deliver(self.pos, construction.pos, ty, &envs.tiles)
+                        } else {
+                            None
+                        }
+                    })
+                    .or_else(|| {
+                        let path_to_source = find_multipath(
+                            [self.pos].into_iter(),
+                            |pos| {
+                                envs.first.iter().chain(envs.last.iter()).any(|o| {
+                                    o.payload
+                                        .as_ref()
+                                        .map(|o| {
+                                            o.pos == pos
+                                                && 0 < o.inventory.get(&ty).copied().unwrap_or(0)
+                                        })
+                                        .unwrap_or(false)
+                                })
+                            },
+                            |_, pos| matches!(envs.tiles[pos].state, TileState::Empty),
+                        );
+                        path_to_source
+                            .and_then(|src| src.first().copied())
+                            .and_then(|src| {
+                                Crew::new_pickup(self.pos, src, construction.pos, ty, envs.tiles)
+                            })
+                    })
+            })
+    }
+}

--- a/game-logic/src/building/crew_cabin.rs
+++ b/game-logic/src/building/crew_cabin.rs
@@ -8,7 +8,7 @@ use super::Building;
 pub(super) struct Envs<'a> {
     pub buildings: &'a EntitySet<Building>,
     pub transports: &'a EntitySet<Transport>,
-    pub crews: &'a [Crew],
+    pub crews: &'a EntitySet<Crew>,
     pub tiles: &'a Tiles,
 }
 

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -156,7 +156,7 @@ impl Construction {
     pub fn required_ingredients<'a>(
         &'a self,
         transports: &'a EntitySet<Transport>,
-        crews: &'a [Crew],
+        crews: &'a EntitySet<Crew>,
     ) -> Box<dyn Iterator<Item = (ItemType, usize)> + 'a> {
         if self.canceling {
             return Box::new(std::iter::empty());

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -7,7 +7,7 @@ use crate::{
     building::{Building, BuildingType},
     crew::{expected_crew_deliveries, Crew},
     direction::Direction,
-    entity::{EntityEntry, EntityId, EntitySet},
+    entity::{EntityId, EntitySet},
     items::{Inventory, ItemType},
     push_pull::{pull_inputs, push_outputs, HasInventory},
     task::{BUILD_CONVEYOR_TIME, BUILD_POWER_GRID_TIME},
@@ -276,8 +276,7 @@ impl AsteroidColoniesGame {
                         &self.tiles,
                         &mut self.transports,
                         construction,
-                        &mut self.buildings,
-                        &mut [],
+                        self.buildings.iter_mut(),
                         &|_| true,
                     );
                     crate::console_log!("Pushed out after: {:?}", construction.ingredients);
@@ -292,7 +291,7 @@ impl AsteroidColoniesGame {
                     construction.pos,
                     size,
                     &mut construction.ingredients,
-                    &mut self.buildings,
+                    self.buildings.as_mut(),
                     &mut [],
                 );
                 // TODO: should we always use the same amount of time to deconstruct as construction?
@@ -303,14 +302,7 @@ impl AsteroidColoniesGame {
                 let pos = construction.pos;
                 match construction.type_ {
                     ConstructionType::Building(ty) => {
-                        let b = self.buildings.iter_mut().find(|c| c.payload.is_none());
-                        if let Some(b) = b {
-                            b.gen += 1;
-                            b.payload = Some(Building::new(pos, ty));
-                        } else {
-                            self.buildings
-                                .push(EntityEntry::new(Building::new(pos, ty)));
-                        }
+                        self.buildings.insert(Building::new(pos, ty));
                     }
                     ConstructionType::PowerGrid => {
                         if let Some(tile) = self.tiles.try_get_mut(pos) {

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -4,6 +4,7 @@ use crate::{
     building::{Building, BuildingType},
     crew::{expected_crew_deliveries, Crew},
     direction::Direction,
+    entity::EntityEntry,
     items::{Inventory, ItemType},
     push_pull::{pull_inputs, push_outputs, HasInventory},
     task::{BUILD_CONVEYOR_TIME, BUILD_POWER_GRID_TIME},
@@ -272,7 +273,8 @@ impl AsteroidColoniesGame {
                 let pos = construction.pos;
                 match construction.type_ {
                     ConstructionType::Building(ty) => {
-                        self.buildings.push(Building::new(pos, ty));
+                        self.buildings
+                            .push(EntityEntry::new(Building::new(pos, ty)));
                     }
                     ConstructionType::PowerGrid => {
                         if let Some(tile) = self.tiles.try_get_mut(pos) {

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -31,7 +31,7 @@ pub enum ConstructionType {
 pub struct Construction {
     type_: ConstructionType,
     pub pos: Pos,
-    pub ingredients: HashMap<ItemType, usize>,
+    pub ingredients: Inventory,
     pub recipe: BuildMenuItem,
     canceling: bool,
     pub progress: f64,
@@ -45,7 +45,7 @@ impl Construction {
         Self {
             type_,
             pos,
-            ingredients: HashMap::new(),
+            ingredients: Inventory::new(),
             recipe: (*item).clone(),
             canceling: false,
             progress: 0.,
@@ -94,7 +94,7 @@ impl Construction {
     ) -> Option<Self> {
         let con_ty = ConstructionType::Building(building);
         let recipe = get_build_menu().iter().find(|bi| bi.type_ == con_ty)?;
-        let mut ingredients = recipe.ingredients.clone();
+        let mut ingredients: Inventory = recipe.ingredients.iter().map(|(k, v)| (*k, *v)).collect();
         for (item, amount) in inventory {
             ingredients.insert(*item, *amount);
         }
@@ -222,7 +222,7 @@ impl HasInventory for Construction {
         self.size()
     }
 
-    fn inventory(&mut self) -> &mut HashMap<ItemType, usize> {
+    fn inventory(&mut self) -> &mut Inventory {
         &mut self.ingredients
     }
 }

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -4,7 +4,7 @@ use crate::{
     building::{Building, BuildingType},
     crew::{expected_crew_deliveries, Crew},
     direction::Direction,
-    entity::EntityEntry,
+    entity::{EntityEntry, EntitySet},
     items::{Inventory, ItemType},
     push_pull::{pull_inputs, push_outputs, HasInventory},
     task::{BUILD_CONVEYOR_TIME, BUILD_POWER_GRID_TIME},
@@ -139,7 +139,7 @@ impl Construction {
 
     pub fn required_ingredients<'a>(
         &'a self,
-        transports: &'a [Transport],
+        transports: &'a EntitySet<Transport>,
         crews: &'a [Crew],
     ) -> Box<dyn Iterator<Item = (ItemType, usize)> + 'a> {
         if self.canceling {

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -274,11 +274,10 @@ pub fn get_build_menu() -> &'static [BuildMenuItem] {
 
 impl AsteroidColoniesGame {
     pub(super) fn process_constructions(&mut self) {
-        let mut to_delete = vec![];
-        for (i, construction) in self.constructions.iter_mut().enumerate() {
+        self.constructions.retain(|construction| {
             if construction.canceling {
                 if construction.ingredients.is_empty() {
-                    to_delete.push(i);
+                    return false;
                 } else if construction.progress <= 0. {
                     push_outputs(
                         &self.tiles,
@@ -304,7 +303,7 @@ impl AsteroidColoniesGame {
                 // TODO: should we always use the same amount of time to deconstruct as construction?
                 // Some buildings should be easier to deconstruct than construct.
                 if construction.progress < construction.recipe.time {
-                    continue;
+                    return true;
                 }
                 let pos = construction.pos;
                 match construction.type_ {
@@ -322,12 +321,9 @@ impl AsteroidColoniesGame {
                         }
                     }
                 }
-                to_delete.push(i);
+                return false;
             }
-        }
-
-        for i in to_delete.iter().rev() {
-            self.constructions.remove(*i);
-        }
+            true
+        });
     }
 }

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -273,8 +273,15 @@ impl AsteroidColoniesGame {
                 let pos = construction.pos;
                 match construction.type_ {
                     ConstructionType::Building(ty) => {
-                        self.buildings
-                            .push(EntityEntry::new(Building::new(pos, ty)));
+                        let b = self.buildings
+                            .iter_mut()
+                            .find(|c| c.payload.is_none());
+                        if let Some(b) = b {
+                            b.gen += 1;
+                            b.payload = Some(Building::new(pos, ty));
+                        } else {
+                            self.buildings.push(EntityEntry::new(Building::new(pos, ty)));
+                        }
                     }
                     ConstructionType::PowerGrid => {
                         if let Some(tile) = self.tiles.try_get_mut(pos) {

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -273,14 +273,13 @@ impl AsteroidColoniesGame {
                 let pos = construction.pos;
                 match construction.type_ {
                     ConstructionType::Building(ty) => {
-                        let b = self.buildings
-                            .iter_mut()
-                            .find(|c| c.payload.is_none());
+                        let b = self.buildings.iter_mut().find(|c| c.payload.is_none());
                         if let Some(b) = b {
                             b.gen += 1;
                             b.payload = Some(Building::new(pos, ty));
                         } else {
-                            self.buildings.push(EntityEntry::new(Building::new(pos, ty)));
+                            self.buildings
+                                .push(EntityEntry::new(Building::new(pos, ty)));
                         }
                     }
                     ConstructionType::PowerGrid => {

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -135,6 +135,14 @@ impl Construction {
             && pos[1] <= self.pos[1] + size[1] as i32
     }
 
+    pub fn intersects_rect(&self, pos: Pos, other_size: [usize; 2]) -> bool {
+        let size = self.size();
+        self.pos[0] < pos[0] + other_size[0] as i32
+            && pos[0] < self.pos[0] + size[0] as i32
+            && self.pos[1] < pos[1] + other_size[1] as i32
+            && pos[1] < self.pos[1] + size[1] as i32
+    }
+
     pub fn canceling(&self) -> bool {
         self.canceling
     }

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -276,7 +276,7 @@ impl AsteroidColoniesGame {
                         &self.tiles,
                         &mut self.transports,
                         construction,
-                        self.buildings.iter_mut(),
+                        &self.buildings,
                         &|_| true,
                     );
                     crate::console_log!("Pushed out after: {:?}", construction.ingredients);
@@ -291,8 +291,7 @@ impl AsteroidColoniesGame {
                     construction.pos,
                     size,
                     &mut construction.ingredients,
-                    self.buildings.as_mut(),
-                    &mut [],
+                    &self.buildings,
                 );
                 // TODO: should we always use the same amount of time to deconstruct as construction?
                 // Some buildings should be easier to deconstruct than construct.

--- a/game-logic/src/conveyor.rs
+++ b/game-logic/src/conveyor.rs
@@ -267,7 +267,7 @@ impl AsteroidColoniesGame {
     pub fn commit_build_conveyor(&mut self) -> Vec<Construction> {
         for (pos, conv) in self.conveyor_staged.iter() {
             self.constructions
-                .push(Construction::new_conveyor(*pos, *conv));
+                .insert(Construction::new_conveyor(*pos, *conv));
         }
         self.conveyor_preview.clear();
         std::mem::take(&mut self.conveyor_staged)

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -175,7 +175,7 @@ impl Crew {
         self.task = CrewTask::None;
     }
 
-    fn process_build_task(&mut self, constructions: &mut [Construction], ct_pos: Pos) {
+    fn process_build_task(&mut self, constructions: &mut EntitySet<Construction>, ct_pos: Pos) {
         for con in constructions.iter_mut() {
             let canceling = con.canceling();
             let t = &mut con.progress;
@@ -205,7 +205,7 @@ impl Crew {
         dest: Pos,
         tiles: &Tiles,
         buildings: &mut EntitySet<Building>,
-        constructions: &mut [Construction],
+        constructions: &mut EntitySet<Construction>,
         transports: &mut EntitySet<Transport>,
     ) {
         let mut process_inventory = |inventory: &mut HashMap<ItemType, usize>| {
@@ -269,7 +269,7 @@ impl Crew {
         &mut self,
         item: ItemType,
         dest: Pos,
-        constructions: &mut [Construction],
+        constructions: &mut EntitySet<Construction>,
         buildings: &EntitySet<Building>,
     ) {
         let Some(crew_amount) = self.inventory.get_mut(&item) else {
@@ -297,7 +297,7 @@ impl Crew {
         &mut self,
         crews: &EntitySet<Crew>,
         tiles: &Tiles,
-        constructions: &mut [Construction],
+        constructions: &mut EntitySet<Construction>,
         buildings: &mut EntitySet<Building>,
     ) -> bool {
         let construction = constructions.iter().find(|construction| {

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -5,7 +5,7 @@ use crate::{
     building::Building,
     console_log,
     construction::Construction,
-    entity::{EntityEntry, EntityIterMutExt, EntitySet},
+    entity::EntitySet,
     hash_map,
     items::ItemType,
     task::{GlobalTask, EXCAVATE_ORE_AMOUNT, LABOR_EXCAVATE_TIME},
@@ -193,7 +193,7 @@ impl Crew {
         src: Pos,
         dest: Pos,
         tiles: &Tiles,
-        buildings: &mut [EntityEntry<Building>],
+        buildings: &mut EntitySet<Building>,
         constructions: &mut [Construction],
         transports: &mut EntitySet<Transport>,
     ) {
@@ -224,7 +224,7 @@ impl Crew {
         };
 
         let res =
-            (|| process_inventory(&mut buildings.items_mut().find(|o| intersects(o))?.inventory))()
+            (|| process_inventory(&mut buildings.iter_mut().find(|o| intersects(o))?.inventory))()
                 .or_else(|| {
                     process_inventory(
                         &mut constructions
@@ -275,8 +275,8 @@ impl Crew {
 
 impl AsteroidColoniesGame {
     pub(super) fn process_crews(&mut self) {
-        let try_return = |crew: &mut Crew, buildings: &mut [EntityEntry<Building>]| {
-            if let Some(building) = buildings.items_mut().find(|b| b.pos == crew.from) {
+        let try_return = |crew: &mut Crew, buildings: &mut EntitySet<Building>| {
+            if let Some(building) = buildings.iter_mut().find(|b| b.pos == crew.from) {
                 building.crews += 1;
                 for (item, amount) in &crew.inventory {
                     *building.inventory.entry(*item).or_default() += *amount;

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -245,6 +245,7 @@ impl Crew {
                     })?;
                     self.path = Some(path);
                     self.task = CrewTask::Deliver { dst: dest, item };
+                    drop(transport);
                     transports.remove(idx);
                     Some(())
                 });

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -5,7 +5,7 @@ use crate::{
     building::Building,
     console_log,
     construction::Construction,
-    entity::{EntityEntry, EntityIterMutExt},
+    entity::{EntityEntry, EntityIterMutExt, EntitySet},
     hash_map,
     items::ItemType,
     task::{GlobalTask, EXCAVATE_ORE_AMOUNT, LABOR_EXCAVATE_TIME},
@@ -195,7 +195,7 @@ impl Crew {
         tiles: &Tiles,
         buildings: &mut [EntityEntry<Building>],
         constructions: &mut [Construction],
-        transports: &mut Vec<Transport>,
+        transports: &mut EntitySet<Transport>,
     ) {
         let mut process_inventory = |inventory: &mut HashMap<ItemType, usize>| {
             let Some(item) = item.or_else(|| inventory.keys().copied().next()) else {

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -7,7 +7,7 @@ use crate::{
     construction::Construction,
     entity::{EntityId, EntitySet},
     hash_map,
-    items::ItemType,
+    items::{Inventory, ItemType},
     task::{GlobalTask, EXCAVATE_ORE_AMOUNT, LABOR_EXCAVATE_TIME},
     transport::{find_path, Transport},
     AsteroidColoniesGame, Pos, TileState, Tiles,
@@ -41,8 +41,6 @@ pub struct Crew {
     task: CrewTask,
     inventory: HashMap<ItemType, usize>,
 }
-
-type BuildingSet = EntitySet<Building>;
 
 impl Crew {
     pub fn new_task(
@@ -207,7 +205,7 @@ impl Crew {
         constructions: &mut EntitySet<Construction>,
         transports: &mut EntitySet<Transport>,
     ) {
-        let mut process_inventory = |inventory: &mut HashMap<ItemType, usize>| {
+        let mut process_inventory = |inventory: &mut Inventory| {
             let Some(item) = item.or_else(|| inventory.keys().copied().next()) else {
                 return None;
             };

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -214,8 +214,17 @@ impl Crew {
             self.task = CrewTask::Deliver { dst: dest, item };
             Some(())
         };
+
+        let intersects = |b: &Building| {
+            let size = b.type_.size();
+            b.pos[0] <= src[0]
+                && src[0] < size[0] as i32 + b.pos[0]
+                && b.pos[1] <= src[1]
+                && src[1] < size[1] as i32 + b.pos[1]
+        };
+
         let res =
-            (|| process_inventory(&mut buildings.items_mut().find(|o| o.pos == src)?.inventory))()
+            (|| process_inventory(&mut buildings.items_mut().find(|o| intersects(o))?.inventory))()
                 .or_else(|| {
                     process_inventory(
                         &mut constructions

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -6,6 +6,7 @@ use crate::{
     console_log,
     construction::Construction,
     entity::{EntityEntry, EntityIterMutExt},
+    hash_map,
     items::ItemType,
     task::{GlobalTask, EXCAVATE_ORE_AMOUNT, LABOR_EXCAVATE_TIME},
     transport::{find_path, Transport},
@@ -122,7 +123,7 @@ impl Crew {
             path: Some(path),
             from: pos,
             task: CrewTask::Deliver { dst: dest, item },
-            inventory: HashMap::new(),
+            inventory: hash_map!(item => 1),
             to_delete: false,
         })
     }

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -46,12 +46,11 @@ type BuildingSet = EntitySet<Building>;
 
 impl Crew {
     pub fn new_task(
-        from: EntityId,
+        from_id: EntityId,
+        from_building: &mut Building,
         gtask: &GlobalTask,
         tiles: &Tiles,
-        buildings: &BuildingSet,
     ) -> Option<Self> {
-        let from_building = buildings.get(from)?;
         let (target, task) = match gtask {
             GlobalTask::Excavate(_, pos) => (*pos, CrewTask::Excavate(*pos)),
             GlobalTask::Cleanup(spos) => (
@@ -69,7 +68,7 @@ impl Crew {
         Some(Self {
             pos: from_building.pos,
             path: Some(path),
-            from,
+            from: from_id,
             task,
             inventory: HashMap::new(),
         })

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -5,6 +5,7 @@ use crate::{
     building::Building,
     console_log,
     construction::Construction,
+    entity::{EntityEntry, EntityIterMutExt},
     items::ItemType,
     task::{GlobalTask, EXCAVATE_ORE_AMOUNT, LABOR_EXCAVATE_TIME},
     transport::{find_path, Transport},
@@ -191,7 +192,7 @@ impl Crew {
         src: Pos,
         dest: Pos,
         tiles: &Tiles,
-        buildings: &mut [Building],
+        buildings: &mut [EntityEntry<Building>],
         constructions: &mut [Construction],
         transports: &mut Vec<Transport>,
     ) {
@@ -213,7 +214,7 @@ impl Crew {
             Some(())
         };
         let res =
-            (|| process_inventory(&mut buildings.iter_mut().find(|o| o.pos == src)?.inventory))()
+            (|| process_inventory(&mut buildings.items_mut().find(|o| o.pos == src)?.inventory))()
                 .or_else(|| {
                     process_inventory(
                         &mut constructions
@@ -265,8 +266,8 @@ impl Crew {
 
 impl AsteroidColoniesGame {
     pub(super) fn process_crews(&mut self) {
-        let try_return = |crew: &mut Crew, buildings: &mut [Building]| {
-            if let Some(building) = buildings.iter_mut().find(|b| b.pos == crew.from) {
+        let try_return = |crew: &mut Crew, buildings: &mut [EntityEntry<Building>]| {
+            if let Some(building) = buildings.items_mut().find(|b| b.pos == crew.from) {
                 building.crews += 1;
                 for (item, amount) in &crew.inventory {
                     *building.inventory.entry(*item).or_default() += *amount;

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -235,8 +235,7 @@ impl Crew {
                 })
                 .or_else(|| {
                     let (idx, transport) = transports
-                        .iter()
-                        .enumerate()
+                        .items()
                         .find(|(_, t)| t.path.last() == Some(&src))?;
                     println!("Found transports: {idx}, {transport:?}");
                     let item = transport.item;

--- a/game-logic/src/entity.rs
+++ b/game-logic/src/entity.rs
@@ -68,6 +68,17 @@ impl<T> EntitySet<T> {
             .get_mut(id.id as usize)
             .and_then(|entry| entry.payload.take())
     }
+
+    pub fn retain(&mut self, f: impl Fn(&T) -> bool) {
+        for entry in &mut self.v {
+            let Some(payload) = entry.payload.as_mut() else {
+                continue;
+            };
+            if !f(payload) {
+                entry.payload = None;
+            }
+        }
+    }
 }
 
 /// An inefficient implementation of IntoIterator.

--- a/game-logic/src/entity.rs
+++ b/game-logic/src/entity.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 /// An entry in entity list with generational ids, with the payload and the generation
 pub struct EntityEntry<T> {
     pub gen: u32,
@@ -13,6 +13,65 @@ impl<T> EntityEntry<T> {
             gen: 0,
             payload: Some(payload),
         }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct EntitySet<T> {
+    v: Vec<EntityEntry<T>>,
+}
+
+impl<T> EntitySet<T> {
+    pub fn new() -> Self {
+        Self { v: vec![] }
+    }
+
+    pub fn len(&self) -> usize {
+        // TODO: optimize by caching active elements
+        self.v
+            .iter()
+            .filter(|entry| entry.payload.is_some())
+            .count()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.v.iter().filter_map(|v| v.payload.as_ref())
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.v.iter_mut().filter_map(|v| v.payload.as_mut())
+    }
+
+    pub fn items(&self) -> impl Iterator<Item = (usize, &T)> {
+        self.v
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| Some((i, v.payload.as_ref()?)))
+    }
+
+    pub fn insert(&mut self, val: T) -> usize {
+        for (i, entry) in self.v.iter_mut().enumerate() {
+            if entry.payload.is_none() {
+                entry.payload = Some(val);
+                return i;
+            }
+        }
+        self.v.push(EntityEntry::new(val));
+        self.v.len() - 1
+    }
+
+    pub fn remove(&mut self, idx: usize) -> Option<T> {
+        self.v.get_mut(idx).and_then(|entry| entry.payload.take())
+    }
+}
+
+/// An inefficient implementation of IntoIterator.
+/// TODO: remove Box
+impl<'a, T> IntoIterator for &'a EntitySet<T> {
+    type Item = &'a T;
+    type IntoIter = Box<dyn Iterator<Item = &'a T> + 'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        Box::new(self.v.iter().filter_map(|v| v.payload.as_ref()))
     }
 }
 

--- a/game-logic/src/entity.rs
+++ b/game-logic/src/entity.rs
@@ -159,15 +159,18 @@ impl<T> EntitySet<T> {
         }
     }
 
-    pub fn retain_borrow_mut(&self, mut f: impl FnMut(&mut T) -> bool) {
-        for entry in &self.v {
+    pub fn retain_borrow_mut(&self, mut f: impl FnMut(&mut T, EntityId) -> bool) {
+        for (id, entry) in self.v.iter().enumerate() {
             let Ok(mut payload) = entry.payload.try_borrow_mut() else {
                 continue;
             };
             if payload.is_none() {
                 continue;
             }
-            if !f(payload.as_mut().unwrap()) {
+            if !f(
+                payload.as_mut().unwrap(),
+                EntityId::new(id as u32, entry.gen),
+            ) {
                 *payload = None;
             }
         }

--- a/game-logic/src/entity.rs
+++ b/game-logic/src/entity.rs
@@ -1,0 +1,78 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+/// An entry in entity list with generational ids, with the payload and the generation
+pub struct EntityEntry<T> {
+    pub gen: u32,
+    pub payload: Option<T>,
+}
+
+impl<T> EntityEntry<T> {
+    pub(crate) fn new(payload: T) -> Self {
+        Self {
+            gen: 0,
+            payload: Some(payload),
+        }
+    }
+}
+
+/// An extension trait to allow a container to iterate over valid items
+pub trait EntityIterExt<T> {
+    /// Iterate items in each entry's payload
+    fn items<'a>(&'a self) -> impl Iterator<Item = &'a T>
+    where
+        T: 'a;
+}
+
+impl<T> EntityIterExt<T> for &[EntityEntry<T>] {
+    fn items<'a>(&'a self) -> impl Iterator<Item = &'a T>
+    where
+        T: 'a,
+    {
+        self.iter().filter_map(|b| b.payload.as_ref())
+    }
+}
+
+/// An extension trait to allow a container to mutably iterate over valid items
+pub trait EntityIterMutExt<T>: EntityIterExt<T> {
+    /// Mutably iterate items in each entry's payload
+    fn items_mut<'a>(&'a mut self) -> impl Iterator<Item = &'a mut T>
+    where
+        T: 'a;
+}
+
+impl<T> EntityIterExt<T> for [EntityEntry<T>] {
+    fn items<'a>(&'a self) -> impl Iterator<Item = &'a T>
+    where
+        T: 'a,
+    {
+        self.iter().filter_map(|b| b.payload.as_ref())
+    }
+}
+
+impl<T> EntityIterMutExt<T> for [EntityEntry<T>] {
+    fn items_mut<'a>(&'a mut self) -> impl Iterator<Item = &'a mut T>
+    where
+        T: 'a,
+    {
+        self.iter_mut().filter_map(|b| b.payload.as_mut())
+    }
+}
+
+impl<T> EntityIterExt<T> for Vec<EntityEntry<T>> {
+    fn items<'a>(&'a self) -> impl Iterator<Item = &'a T>
+    where
+        T: 'a,
+    {
+        self.iter().filter_map(|b| b.payload.as_ref())
+    }
+}
+
+impl<T> EntityIterMutExt<T> for Vec<EntityEntry<T>> {
+    fn items_mut<'a>(&'a mut self) -> impl Iterator<Item = &'a mut T>
+    where
+        T: 'a,
+    {
+        self.iter_mut().filter_map(|b| b.payload.as_mut())
+    }
+}

--- a/game-logic/src/entity.rs
+++ b/game-logic/src/entity.rs
@@ -24,15 +24,6 @@ pub trait EntityIterExt<T> {
         T: 'a;
 }
 
-impl<T> EntityIterExt<T> for &[EntityEntry<T>] {
-    fn items<'a>(&'a self) -> impl Iterator<Item = &'a T>
-    where
-        T: 'a,
-    {
-        self.iter().filter_map(|b| b.payload.as_ref())
-    }
-}
-
 /// An extension trait to allow a container to mutably iterate over valid items
 pub trait EntityIterMutExt<T>: EntityIterExt<T> {
     /// Mutably iterate items in each entry's payload

--- a/game-logic/src/entity.rs
+++ b/game-logic/src/entity.rs
@@ -124,7 +124,7 @@ impl<T> EntitySet<T> {
     //     })
     // }
 
-    pub fn retain(&mut self, f: impl Fn(&T) -> bool) {
+    pub fn retain(&mut self, mut f: impl FnMut(&mut T) -> bool) {
         for entry in &mut self.v {
             let Some(payload) = entry.payload.as_mut() else {
                 continue;

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, io::Read};
 
 use crate::{
+    btree_map,
     building::{Building, BuildingType, Recipe},
     console_log,
     construction::{get_build_menu, Construction, ConstructionType},
@@ -9,7 +10,6 @@ use crate::{
     crew::Crew,
     direction::Direction,
     entity::{EntitySet, RefOption},
-    hash_map,
     items::{recipes, ItemType},
     push_pull::send_item,
     task::{GlobalTask, Task, MOVE_TIME},
@@ -65,7 +65,7 @@ impl AsteroidColoniesGame {
             Building::new_inventory(
                 start_ofs([6, 3]),
                 BuildingType::MediumStorage,
-                hash_map!(ItemType::ConveyorComponent => 20, ItemType::PowerGridComponent => 2),
+                btree_map!(ItemType::ConveyorComponent => 20, ItemType::PowerGridComponent => 2),
             ),
             Building::new(start_ofs([1, 10]), BuildingType::Assembler),
             Building::new(start_ofs([1, 4]), BuildingType::Furnace),

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{cell::Ref, collections::HashMap, io::Read};
+use std::{collections::HashMap, io::Read};
 
 use crate::{
     building::{Building, BuildingType, Recipe},
@@ -8,7 +8,7 @@ use crate::{
     conveyor::Conveyor,
     crew::Crew,
     direction::Direction,
-    entity::EntitySet,
+    entity::{EntitySet, RefOption},
     hash_map,
     items::{recipes, ItemType},
     push_pull::send_item,
@@ -164,7 +164,7 @@ impl AsteroidColoniesGame {
         &self.tiles[pos]
     }
 
-    pub fn iter_building(&self) -> impl Iterator<Item = Ref<Building>> {
+    pub fn iter_building(&self) -> impl Iterator<Item = RefOption<Building>> {
         self.buildings.iter()
     }
 
@@ -172,7 +172,7 @@ impl AsteroidColoniesGame {
         self.constructions.iter()
     }
 
-    pub fn iter_crew(&self) -> impl Iterator<Item = Ref<Crew>> {
+    pub fn iter_crew(&self) -> impl Iterator<Item = RefOption<Crew>> {
         self.crews.iter()
     }
 
@@ -184,7 +184,7 @@ impl AsteroidColoniesGame {
         self.transports.len()
     }
 
-    pub fn iter_transport(&self) -> impl Iterator<Item = Ref<Transport>> {
+    pub fn iter_transport(&self) -> impl Iterator<Item = RefOption<Transport>> {
         self.transports.iter()
     }
 

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -11,6 +11,7 @@ use crate::{
     entity::EntitySet,
     hash_map,
     items::{recipes, ItemType},
+    push_pull::send_item,
     task::{GlobalTask, Task, MOVE_TIME},
     tile::CHUNK_SIZE,
     transport::{find_path, Transport},
@@ -232,6 +233,22 @@ impl AsteroidColoniesGame {
         path.pop();
         building.task = Task::Move(MOVE_TIME, path);
         Ok(())
+    }
+
+    pub fn move_item(&mut self, from: Pos, to: Pos) -> Result<(), String> {
+        let mut src = self
+            .buildings
+            .iter_borrow_mut()
+            .find(|b| b.intersects(from))
+            .ok_or_else(|| "Moving an item needs a building at the source")?;
+        send_item(
+            &mut self.tiles,
+            &mut self.transports,
+            &mut *src,
+            to,
+            &self.buildings,
+            &|_| true,
+        )
     }
 
     pub fn build(&mut self, ix: i32, iy: i32, type_: BuildingType) -> Result<(), String> {

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -8,7 +8,7 @@ use crate::{
     conveyor::Conveyor,
     crew::Crew,
     direction::Direction,
-    entity::{EntityEntry, EntityIterExt, EntityIterMutExt},
+    entity::{EntityEntry, EntityIterExt, EntityIterMutExt, EntitySet},
     hash_map,
     items::{recipes, ItemType},
     task::{GlobalTask, Task, MOVE_TIME},
@@ -27,7 +27,7 @@ pub struct AsteroidColoniesGame {
     /// Used power for the last tick, in kW
     pub(crate) used_power: usize,
     pub(crate) global_time: usize,
-    pub(crate) transports: Vec<Transport>,
+    pub(crate) transports: EntitySet<Transport>,
     pub(crate) constructions: Vec<Construction>,
     /// Ghost conveyors staged for commit. After committing, they will be queued to construction plans
     pub(crate) conveyor_staged: HashMap<Pos, Conveyor>,
@@ -135,7 +135,7 @@ impl AsteroidColoniesGame {
             global_tasks: vec![],
             used_power: 0,
             global_time: 0,
-            transports: vec![],
+            transports: EntitySet::new(),
             constructions: vec![],
             conveyor_staged: HashMap::new(),
             conveyor_preview: HashMap::new(),
@@ -486,7 +486,7 @@ pub struct SerializeGame {
     crews: Vec<Crew>,
     global_tasks: Vec<GlobalTask>,
     global_time: usize,
-    transports: Vec<Transport>,
+    transports: EntitySet<Transport>,
     constructions: Vec<Construction>,
     rng: Xor128,
 }

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -22,7 +22,7 @@ pub type CalculateBackImage = Box<dyn Fn(&mut Tiles) + Send + Sync>;
 pub struct AsteroidColoniesGame {
     pub(crate) tiles: Tiles,
     pub(crate) buildings: EntitySet<Building>,
-    pub(crate) crews: Vec<Crew>,
+    pub(crate) crews: EntitySet<Crew>,
     pub(crate) global_tasks: Vec<GlobalTask>,
     /// Used power for the last tick, in kW
     pub(crate) used_power: usize,
@@ -130,7 +130,7 @@ impl AsteroidColoniesGame {
         Ok(Self {
             tiles,
             buildings,
-            crews: vec![],
+            crews: EntitySet::new(),
             global_tasks: vec![],
             used_power: 0,
             global_time: 0,
@@ -171,7 +171,7 @@ impl AsteroidColoniesGame {
         self.constructions.iter()
     }
 
-    pub fn iter_crew(&self) -> impl Iterator<Item = &Crew> {
+    pub fn iter_crew(&self) -> impl Iterator<Item = Ref<Crew>> {
         self.crews.iter()
     }
 
@@ -469,7 +469,7 @@ impl AsteroidColoniesGame {
 pub struct SerializeGame {
     tiles: Tiles,
     buildings: EntitySet<Building>,
-    crews: Vec<Crew>,
+    crews: EntitySet<Crew>,
     global_tasks: Vec<GlobalTask>,
     global_time: usize,
     transports: EntitySet<Transport>,

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -320,14 +320,14 @@ impl AsteroidColoniesGame {
     }
 
     pub fn set_recipe(&mut self, ix: i32, iy: i32, name: Option<&str>) -> Result<(), String> {
-        let Some(assembler) = self.buildings.iter().find(|b| b.intersects([ix, iy])) else {
-            return Err(String::from("The building does not exist at the target"));
+        let Some(assembler) = self.buildings.iter_mut().find(|b| b.intersects([ix, iy])) else {
+            return Err("The building does not exist at the target".to_string());
         };
         if !matches!(assembler.type_, BuildingType::Assembler) {
             return Err(String::from("The building is not an assembler"));
         }
         let Some(name) = name else {
-            self.set_building_recipe(ix, iy, None)?;
+            assembler.set_recipe(None)?;
             return Ok(());
         };
         for recipe in recipes() {
@@ -335,7 +335,7 @@ impl AsteroidColoniesGame {
                 continue;
             };
             if format!("{:?}", key) == name {
-                self.set_building_recipe(ix, iy, Some(recipe))?;
+                assembler.set_recipe(Some(recipe))?;
                 break;
             }
         }

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -306,17 +306,23 @@ impl AsteroidColoniesGame {
     }
 
     pub fn deconstruct(&mut self, ix: i32, iy: i32) -> Result<(), String> {
-        let (i, b) = self
+        let b = self
             .buildings
-            .items()
-            .enumerate()
-            .find(|(_, c)| c.pos == [ix, iy])
+            .iter_mut()
+            .find(|c| {
+                c.payload
+                    .as_ref()
+                    .map(|c| c.pos == [ix, iy])
+                    .unwrap_or(false)
+            })
             .ok_or_else(|| String::from("Building not found at given position"))?;
-        let decon = Construction::new_deconstruct(b.type_, [ix, iy], &b.inventory)
-            .ok_or_else(|| String::from("No build recipe was found to deconstruct"))?;
+        if let Some(ref b) = b.payload {
+            let decon = Construction::new_deconstruct(b.type_, [ix, iy], &b.inventory)
+                .ok_or_else(|| String::from("No build recipe was found to deconstruct"))?;
+            self.constructions.push(decon);
+        }
 
-        self.constructions.push(decon);
-        self.buildings.remove(i);
+        b.payload = None;
 
         Ok(())
     }

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -437,6 +437,31 @@ impl AsteroidColoniesGame {
         self.transports = ser_data.transports;
         self.constructions = ser_data.constructions;
         self.rng = ser_data.rng;
+
+        // Clear transports expectation cache
+        for building in self.buildings.items_mut() {
+            building.expected_transports.clear();
+        }
+
+        // Clear transports expectation cache
+        for construction in &mut self.constructions {
+            construction.clear_expected_all();
+        }
+
+        // Reconstruct transports expectation cache from actual data
+        for (id, t) in self.transports.items() {
+            let Some(t_pos) = t.path.last() else {
+                continue;
+            };
+            if let Some(building) = self.buildings.items_mut().find(|b| b.intersects(*t_pos)) {
+                building.expected_transports.insert(id);
+            } else if let Some(construction) =
+                self.constructions.iter_mut().find(|c| c.intersects(*t_pos))
+            {
+                construction.insert_expected_transports(id);
+            }
+        }
+
         if let Some(ref f) = self.calculate_back_image {
             f(&mut self.tiles);
         }

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -194,8 +194,8 @@ impl AsteroidColoniesGame {
             .chain(self.conveyor_preview.iter())
     }
 
-    pub fn move_building(&mut self, ix: i32, iy: i32, dx: i32, dy: i32) -> Result<(), String> {
-        let Some(building) = self.buildings.iter_mut().find(|b| b.pos == [ix, iy]) else {
+    pub fn move_building(&mut self, src: Pos, dest: Pos) -> Result<(), String> {
+        let Some(building) = self.buildings.iter_mut().find(|b| b.pos == src) else {
             return Err(String::from("Building does not exist at that position"));
         };
         if !building.type_.is_mobile() {
@@ -219,14 +219,14 @@ impl AsteroidColoniesGame {
             })
         };
 
-        let mut path = find_path([ix, iy], [dx, dy], |pos| {
+        let mut path = find_path(src, dest, |pos| {
             let tile = &tiles[pos];
             !intersects(pos) && matches!(tile.state, TileState::Empty) && tile.power_grid
         })
         .ok_or_else(|| String::from("Failed to find the path"))?;
 
         // Re-borrow to avoid borrow checker
-        let Some(building) = self.buildings.iter_mut().find(|b| b.pos == [ix, iy]) else {
+        let Some(building) = self.buildings.iter_mut().find(|b| b.pos == src) else {
             return Err(String::from("Building does not exist at that position"));
         };
         path.pop();

--- a/game-logic/src/game.rs
+++ b/game-logic/src/game.rs
@@ -235,10 +235,6 @@ impl AsteroidColoniesGame {
     }
 
     pub fn build(&mut self, ix: i32, iy: i32, type_: BuildingType) -> Result<(), String> {
-        if ix < 0 || WIDTH as i32 <= ix || iy < 0 || HEIGHT as i32 <= iy {
-            return Err(String::from("Point outside tile"));
-        }
-
         let size = type_.size();
         for jy in iy..iy + size[1] as i32 {
             for jx in ix..ix + size[0] as i32 {
@@ -252,18 +248,21 @@ impl AsteroidColoniesGame {
             }
         }
 
-        let tile = &self.tiles[[ix, iy]];
-        if !tile.power_grid {
-            return Err(String::from("Power grid is required to build"));
-        }
-
-        if self.buildings.iter().any(|b| b.intersects([ix, iy])) {
-            return Err(String::from(
-                "The destination is already occupied by a building",
+        if let Some((id, _)) = self
+            .buildings
+            .items()
+            .find(|(_, b)| b.intersects_rect([ix, iy], size))
+        {
+            return Err(format!(
+                "The destination is already occupied by a building {id}",
             ));
         }
 
-        if self.constructions.iter().any(|c| c.intersects([ix, iy])) {
+        if self
+            .constructions
+            .iter()
+            .any(|c| c.intersects_rect([ix, iy], size))
+        {
             return Err(String::from(
                 "The destination is already occupied by a construction plan",
             ));

--- a/game-logic/src/items.rs
+++ b/game-logic/src/items.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use ::serde::{Deserialize, Serialize};
 
 use crate::{hash_map, Recipe};
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
 pub enum ItemType {
     /// Freshly dug soil from asteroid body. Hardly useful unless refined
     RawOre,
@@ -57,4 +57,4 @@ pub(crate) fn recipes() -> &'static [Recipe] {
     })
 }
 
-pub type Inventory = HashMap<ItemType, usize>;
+pub type Inventory = BTreeMap<ItemType, usize>;

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -16,6 +16,7 @@ pub mod construction;
 pub mod conveyor;
 mod crew;
 mod direction;
+mod entity;
 mod game;
 mod items;
 mod push_pull;

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -68,3 +68,15 @@ pub const WIDTH: usize = 100;
 pub const HEIGHT: usize = 100;
 
 pub type Pos = [i32; 2];
+
+#[cfg(not(target_arch = "wasm32"))]
+fn measure_time<T>(f: impl FnOnce() -> T) -> (T, f64) {
+    let start = std::time::Instant::now();
+    let ret = f();
+    (ret, start.elapsed().as_secs_f64())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn measure_time<T>(f: impl FnOnce() -> T) -> (T, f64) {
+    (f(), 0.)
+}

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -5,7 +5,7 @@ pub use crate::{
     crew::Crew,
     direction::Direction,
     game::{AsteroidColoniesGame, SerializeGame},
-    items::ItemType,
+    items::{Inventory, ItemType},
     tile::{new_hasher, Chunk, ImageIdx, Position, Tile, TileState, Tiles, CHUNK_SIZE},
     transport::Transport,
     xor128::Xor128,
@@ -38,6 +38,22 @@ macro_rules! hash_map {
     };
     { } => {
         ::std::collections::HashMap::new()
+    }
+}
+
+#[macro_export]
+macro_rules! btree_map {
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = ::std::collections::BTreeMap::new();
+            $(
+                m.insert($key, $value);
+            )+
+            m
+        }
+    };
+    { } => {
+        ::std::collections::BTreeMap::new()
     }
 }
 

--- a/game-logic/src/push_pull.rs
+++ b/game-logic/src/push_pull.rs
@@ -8,7 +8,7 @@ use crate::{
     building::Building,
     conveyor::Conveyor,
     direction::Direction,
-    entity::{EntityEntry, EntityIterMutExt},
+    entity::{EntityEntry, EntityIterMutExt, EntitySet},
     items::ItemType,
     transport::{expected_deliveries, find_multipath_should_expand, CPos, LevelTarget, Transport},
     Pos, Tile, Tiles, WIDTH,
@@ -42,7 +42,7 @@ impl TileSampler for Tiles {
 pub(crate) fn pull_inputs(
     inputs: &HashMap<ItemType, usize>,
     tiles: &impl TileSampler,
-    transports: &mut Vec<Transport>,
+    transports: &mut EntitySet<Transport>,
     this_pos: Pos,
     this_size: [usize; 2],
     this_inventory: &mut HashMap<ItemType, usize>,
@@ -89,7 +89,7 @@ pub(crate) fn pull_inputs(
         };
         let src_count = src.inventory.entry(*ty).or_default();
         let amount = (*src_count).min(*count - this_count);
-        transports.push(Transport {
+        transports.insert(Transport {
             src: src.pos,
             dest: this_pos,
             path,
@@ -153,7 +153,7 @@ impl HasInventory for Building {
 
 pub(crate) fn push_outputs(
     tiles: &impl TileSampler,
-    transports: &mut Vec<Transport>,
+    transports: &mut EntitySet<Transport>,
     this: &mut impl HasInventory,
     first: &mut [EntityEntry<Building>],
     last: &mut [EntityEntry<Building>],
@@ -212,7 +212,7 @@ pub(crate) fn push_outputs(
             .iter_mut()
             .find(|(t, count)| is_output(**t) && 0 < **count);
         if let Some((&item, amount)) = product {
-            transports.push(Transport {
+            transports.insert(Transport {
                 src: pos,
                 dest: dest.pos,
                 path,

--- a/game-logic/src/push_pull.rs
+++ b/game-logic/src/push_pull.rs
@@ -2,16 +2,13 @@
 #[cfg(test)]
 mod tests;
 
-use std::{
-    cell::RefMut,
-    collections::{HashMap, HashSet},
-};
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     building::Building,
     conveyor::Conveyor,
     direction::Direction,
-    entity::{EntityEntry, EntityId, EntitySet},
+    entity::{EntityEntry, EntityId, EntitySet, RefMutOption},
     items::ItemType,
     transport::{expected_deliveries, find_multipath_should_expand, CPos, LevelTarget, Transport},
     Pos, Tile, Tiles, WIDTH,
@@ -118,10 +115,9 @@ fn _find_from_other_inventory_mut<'a>(
     last: &'a mut [EntityEntry<Building>],
 ) -> Option<(&'a mut Building, usize)> {
     first.iter_mut().chain(last.iter_mut()).find_map(|o| {
-        let Some(ref mut o) = o.payload else {
+        let Some(ref mut o) = o.payload.get_mut() else {
             return None;
         };
-        let o = o.get_mut();
         let count = *o.inventory.get(&item)?;
         if count == 0 {
             return None;
@@ -133,7 +129,7 @@ fn _find_from_other_inventory_mut<'a>(
 fn find_from_inventory_mut<'a>(
     item: ItemType,
     buildings: &'a EntitySet<Building>,
-) -> Option<(RefMut<'a, Building>, usize)> {
+) -> Option<(RefMutOption<'a, Building>, usize)> {
     buildings.iter_borrow_mut().find_map(|o| {
         let count = *o.inventory.get(&item)?;
         if count == 0 {

--- a/game-logic/src/push_pull.rs
+++ b/game-logic/src/push_pull.rs
@@ -8,7 +8,7 @@ use crate::{
     building::Building,
     conveyor::Conveyor,
     direction::Direction,
-    entity::EntityEntry,
+    entity::{EntityEntry, EntityIterMutExt},
     items::ItemType,
     transport::{expected_deliveries, find_multipath_should_expand, CPos, LevelTarget, Transport},
     Pos, Tile, Tiles, WIDTH,
@@ -55,6 +55,7 @@ pub(crate) fn pull_inputs(
             && this_pos[1] <= iy
             && iy < this_size[1] as i32 + this_pos[1]
     };
+    // let start = std::time::Instant::now();
     // crate::console_log!("pulling to at {:?} size {:?}", this_pos, this_size);
     let expected = expected_deliveries(transports, this_pos);
     for (ty, count) in inputs {
@@ -101,6 +102,8 @@ pub(crate) fn pull_inputs(
             *src_count -= amount;
         }
     }
+    // let time = start.elapsed().as_secs_f64();
+    // println!("pull_inputs took {} sec", time);
 }
 
 fn find_from_other_inventory_mut<'a>(
@@ -166,10 +169,8 @@ pub(crate) fn push_outputs(
     //     size,
     //     start_neighbors
     // );
-    let dest = first.iter_mut().chain(last.iter_mut()).find_map(|b| {
-        let Some(b) = b.payload.as_mut() else {
-            return None;
-        };
+    // let start = std::time::Instant::now();
+    let dest = first.items_mut().chain(last.items_mut()).find_map(|b| {
         if !b.type_.is_storage() {
             return None;
         }
@@ -201,6 +202,9 @@ pub(crate) fn push_outputs(
         )?;
         Some((b, path))
     });
+    // let time = start.elapsed().as_secs_f64();
+    // println!("searching {:?} nodes path took {} sec", dest.as_ref().map(|(_, path)| path.len()), time);
+
     // Push away outputs
     if let Some((dest, path)) = dest {
         let product = this

--- a/game-logic/src/push_pull.rs
+++ b/game-logic/src/push_pull.rs
@@ -2,14 +2,14 @@
 #[cfg(test)]
 mod tests;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use crate::{
     building::Building,
     conveyor::Conveyor,
     direction::Direction,
     entity::{EntityEntry, EntityId, EntitySet, RefMutOption},
-    items::ItemType,
+    items::{Inventory, ItemType},
     transport::{expected_deliveries, find_multipath_should_expand, CPos, LevelTarget, Transport},
     Pos, Tile, Tiles, WIDTH,
 };
@@ -39,14 +39,14 @@ impl TileSampler for Tiles {
 }
 
 /// Pull inputs over transportation network
-pub(crate) fn pull_inputs(
-    inputs: &HashMap<ItemType, usize>,
+pub(crate) fn pull_inputs<'a>(
+    inputs: impl IntoIterator<Item = (&'a ItemType, &'a usize)>,
     tiles: &impl TileSampler,
     transports: &mut EntitySet<Transport>,
     expected_transports: &mut HashSet<EntityId>,
     this_pos: Pos,
     this_size: [usize; 2],
-    this_inventory: &mut HashMap<ItemType, usize>,
+    this_inventory: &mut Inventory,
     buildings: &EntitySet<Building>,
 ) {
     let intersects_goal = |[ix, iy]: [i32; 2]| {
@@ -163,7 +163,7 @@ pub(crate) fn rect_iter(pos: Pos, size: [usize; 2]) -> impl Iterator<Item = Pos>
 pub(crate) trait HasInventory {
     fn pos(&self) -> Pos;
     fn size(&self) -> [usize; 2];
-    fn inventory(&mut self) -> &mut HashMap<ItemType, usize>;
+    fn inventory(&mut self) -> &mut Inventory;
 }
 
 impl HasInventory for Building {
@@ -175,7 +175,7 @@ impl HasInventory for Building {
         self.type_.size()
     }
 
-    fn inventory(&mut self) -> &mut HashMap<ItemType, usize> {
+    fn inventory(&mut self) -> &mut Inventory {
         &mut self.inventory
     }
 }

--- a/game-logic/src/push_pull/tests.rs
+++ b/game-logic/src/push_pull/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{building::BuildingType, items::Inventory};
+use crate::{btree_map, building::BuildingType, items::Inventory};
 
 struct MockTiles;
 
@@ -32,8 +32,7 @@ impl TileSampler for MockTiles {
 
 #[test]
 fn test_pull_inputs() {
-    let mut inputs = HashMap::new();
-    inputs.insert(ItemType::RawOre, 1);
+    let inputs = btree_map!(ItemType::RawOre => 1);
 
     let storage: EntitySet<_> = [Building::new_inventory(
         [1, -1],
@@ -52,7 +51,7 @@ fn test_pull_inputs() {
         &mut HashSet::new(),
         [1, 3],
         [1, 1],
-        &mut HashMap::new(),
+        &mut Inventory::new(),
         &storage,
     );
 
@@ -206,8 +205,7 @@ fn print_board(tiles: &impl TileSampler) {
 
 #[test]
 fn test_pull_inputs2() {
-    let mut inputs = HashMap::new();
-    inputs.insert(ItemType::RawOre, 1);
+    let inputs = btree_map!(ItemType::RawOre => 1);
 
     let storage = [Building::new_inventory(
         [1, -1],
@@ -226,7 +224,7 @@ fn test_pull_inputs2() {
         &mut HashSet::new(),
         [1, 4],
         [1, 1],
-        &mut HashMap::new(),
+        &mut Inventory::new(),
         &storage,
     );
 

--- a/game-logic/src/push_pull/tests.rs
+++ b/game-logic/src/push_pull/tests.rs
@@ -35,11 +35,11 @@ fn test_pull_inputs() {
     let mut inputs = HashMap::new();
     inputs.insert(ItemType::RawOre, 1);
 
-    let mut storage = [Building::new_inventory(
+    let mut storage = [EntityEntry::new(Building::new_inventory(
         [1, -1],
         BuildingType::Storage,
         inputs.clone(),
-    )];
+    ))];
 
     let mut transports = vec![];
 
@@ -84,7 +84,7 @@ impl HasInventory for MockInventory {
 
 #[test]
 fn test_push_outputs() {
-    let mut storage = [Building::new([1, -1], BuildingType::Storage)];
+    let mut storage = [EntityEntry::new(Building::new([1, -1], BuildingType::Storage))];
 
     let mut transports = vec![];
 
@@ -206,11 +206,11 @@ fn test_pull_inputs2() {
     let mut inputs = HashMap::new();
     inputs.insert(ItemType::RawOre, 1);
 
-    let mut storage = [Building::new_inventory(
+    let mut storage = [EntityEntry::new(Building::new_inventory(
         [1, -1],
         BuildingType::Storage,
         inputs.clone(),
-    )];
+    ))];
 
     let mut transports = vec![];
 
@@ -248,7 +248,7 @@ fn test_pull_inputs2() {
 
 #[test]
 fn test_push_outputs2() {
-    let mut storage = [Building::new([1, -1], BuildingType::Storage)];
+    let mut storage = [EntityEntry::new(Building::new([1, -1], BuildingType::Storage))];
 
     let mut transports = vec![];
 

--- a/game-logic/src/push_pull/tests.rs
+++ b/game-logic/src/push_pull/tests.rs
@@ -35,11 +35,13 @@ fn test_pull_inputs() {
     let mut inputs = HashMap::new();
     inputs.insert(ItemType::RawOre, 1);
 
-    let mut storage = [EntityEntry::new(Building::new_inventory(
+    let mut storage: EntitySet<_> = [Building::new_inventory(
         [1, -1],
         BuildingType::Storage,
         inputs.clone(),
-    ))];
+    )]
+    .into_iter()
+    .collect();
 
     let mut transports = EntitySet::new();
 
@@ -47,10 +49,11 @@ fn test_pull_inputs() {
         &inputs,
         &MockTiles,
         &mut transports,
+        &mut HashSet::new(),
         [1, 3],
         [1, 1],
         &mut HashMap::new(),
-        &mut storage,
+        storage.as_mut(),
         &mut [],
     );
 
@@ -84,10 +87,9 @@ impl HasInventory for MockInventory {
 
 #[test]
 fn test_push_outputs() {
-    let mut storage = [EntityEntry::new(Building::new(
-        [1, -1],
-        BuildingType::Storage,
-    ))];
+    let mut storage: EntitySet<_> = [Building::new([1, -1], BuildingType::Storage)]
+        .into_iter()
+        .collect();
 
     let mut transports = EntitySet::new();
 
@@ -100,8 +102,7 @@ fn test_push_outputs() {
         &MockTiles,
         &mut transports,
         &mut mock_inventory,
-        &mut storage,
-        &mut [],
+        storage.iter_mut(),
         &|_| true,
     );
 
@@ -221,6 +222,7 @@ fn test_pull_inputs2() {
         &inputs,
         &MockTiles2,
         &mut transports,
+        &mut HashSet::new(),
         [1, 4],
         [1, 1],
         &mut HashMap::new(),
@@ -251,10 +253,9 @@ fn test_pull_inputs2() {
 
 #[test]
 fn test_push_outputs2() {
-    let mut storage = [EntityEntry::new(Building::new(
-        [1, -1],
-        BuildingType::Storage,
-    ))];
+    let mut storage: EntitySet<_> = [Building::new([1, -1], BuildingType::Storage)]
+        .into_iter()
+        .collect();
 
     let mut transports = EntitySet::new();
 
@@ -269,8 +270,7 @@ fn test_push_outputs2() {
         &MockTiles2,
         &mut transports,
         &mut mock_inventory,
-        &mut storage,
-        &mut [],
+        storage.iter_mut(),
         &|_| true,
     );
 

--- a/game-logic/src/push_pull/tests.rs
+++ b/game-logic/src/push_pull/tests.rs
@@ -41,7 +41,7 @@ fn test_pull_inputs() {
         inputs.clone(),
     ))];
 
-    let mut transports = vec![];
+    let mut transports = EntitySet::new();
 
     pull_inputs(
         &inputs,
@@ -54,16 +54,16 @@ fn test_pull_inputs() {
         &mut [],
     );
 
-    assert_eq!(
-        transports,
-        vec![Transport {
-            src: [1, -1],
-            dest: [1, 3],
-            item: ItemType::RawOre,
-            amount: 1,
-            path: vec![[1, 3], [1, 2], [0, 2], [0, 1], [0, 0], [1, 0], [1, -1]],
-        }]
-    )
+    let mut expected = EntitySet::new();
+    expected.insert(Transport {
+        src: [1, -1],
+        dest: [1, 3],
+        item: ItemType::RawOre,
+        amount: 1,
+        path: vec![[1, 3], [1, 2], [0, 2], [0, 1], [0, 0], [1, 0], [1, -1]],
+    });
+
+    assert_eq!(transports, expected)
 }
 
 struct MockInventory(Pos, Inventory);
@@ -89,7 +89,7 @@ fn test_push_outputs() {
         BuildingType::Storage,
     ))];
 
-    let mut transports = vec![];
+    let mut transports = EntitySet::new();
 
     let mut outputs = Inventory::new();
     outputs.insert(ItemType::RawOre, 1);
@@ -105,16 +105,16 @@ fn test_push_outputs() {
         &|_| true,
     );
 
-    assert_eq!(
-        transports,
-        vec![Transport {
-            src: [1, 3],
-            dest: [1, -1],
-            item: ItemType::RawOre,
-            amount: 1,
-            path: vec![[1, -1], [1, 0], [2, 0], [2, 1], [2, 2], [1, 2], [1, 3]],
-        }]
-    )
+    let mut expected = EntitySet::new();
+    expected.insert(Transport {
+        src: [1, 3],
+        dest: [1, -1],
+        item: ItemType::RawOre,
+        amount: 1,
+        path: vec![[1, -1], [1, 0], [2, 0], [2, 1], [2, 2], [1, 2], [1, 3]],
+    });
+
+    assert_eq!(transports, expected)
 }
 
 struct MockTiles2;
@@ -215,7 +215,7 @@ fn test_pull_inputs2() {
         inputs.clone(),
     ))];
 
-    let mut transports = vec![];
+    let mut transports = EntitySet::new();
 
     pull_inputs(
         &inputs,
@@ -228,25 +228,25 @@ fn test_pull_inputs2() {
         &mut [],
     );
 
-    assert_eq!(
-        transports,
-        vec![Transport {
-            src: [1, -1],
-            dest: [1, 4],
-            item: ItemType::RawOre,
-            amount: 1,
-            path: vec![
-                [1, 4],
-                [1, 3],
-                [0, 3],
-                [0, 2],
-                [0, 1],
-                [0, 0],
-                [1, 0],
-                [1, -1]
-            ],
-        }]
-    )
+    let mut expected = EntitySet::new();
+    expected.insert(Transport {
+        src: [1, -1],
+        dest: [1, 4],
+        item: ItemType::RawOre,
+        amount: 1,
+        path: vec![
+            [1, 4],
+            [1, 3],
+            [0, 3],
+            [0, 2],
+            [0, 1],
+            [0, 0],
+            [1, 0],
+            [1, -1],
+        ],
+    });
+
+    assert_eq!(transports, expected)
 }
 
 #[test]
@@ -256,7 +256,7 @@ fn test_push_outputs2() {
         BuildingType::Storage,
     ))];
 
-    let mut transports = vec![];
+    let mut transports = EntitySet::new();
 
     let mut outputs = Inventory::new();
     outputs.insert(ItemType::RawOre, 1);
@@ -274,29 +274,29 @@ fn test_push_outputs2() {
         &|_| true,
     );
 
-    assert_eq!(
-        transports,
-        vec![Transport {
-            src: [1, 4],
-            dest: [1, -1],
-            item: ItemType::RawOre,
-            amount: 1,
-            path: vec![
-                [1, -1],
-                [1, 0],
-                [2, 0],
-                [3, 0],
-                [3, 1],
-                [3, 2],
-                [2, 2],
-                [1, 2],
-                [1, 1],
-                [2, 1],
-                [2, 2],
-                [2, 3],
-                [1, 3],
-                [1, 4]
-            ],
-        }]
-    )
+    let mut expected = EntitySet::new();
+    expected.insert(Transport {
+        src: [1, 4],
+        dest: [1, -1],
+        item: ItemType::RawOre,
+        amount: 1,
+        path: vec![
+            [1, -1],
+            [1, 0],
+            [2, 0],
+            [3, 0],
+            [3, 1],
+            [3, 2],
+            [2, 2],
+            [1, 2],
+            [1, 1],
+            [2, 1],
+            [2, 2],
+            [2, 3],
+            [1, 3],
+            [1, 4],
+        ],
+    });
+
+    assert_eq!(transports, expected)
 }

--- a/game-logic/src/push_pull/tests.rs
+++ b/game-logic/src/push_pull/tests.rs
@@ -84,7 +84,10 @@ impl HasInventory for MockInventory {
 
 #[test]
 fn test_push_outputs() {
-    let mut storage = [EntityEntry::new(Building::new([1, -1], BuildingType::Storage))];
+    let mut storage = [EntityEntry::new(Building::new(
+        [1, -1],
+        BuildingType::Storage,
+    ))];
 
     let mut transports = vec![];
 
@@ -248,7 +251,10 @@ fn test_pull_inputs2() {
 
 #[test]
 fn test_push_outputs2() {
-    let mut storage = [EntityEntry::new(Building::new([1, -1], BuildingType::Storage))];
+    let mut storage = [EntityEntry::new(Building::new(
+        [1, -1],
+        BuildingType::Storage,
+    ))];
 
     let mut transports = vec![];
 

--- a/game-logic/src/push_pull/tests.rs
+++ b/game-logic/src/push_pull/tests.rs
@@ -35,7 +35,7 @@ fn test_pull_inputs() {
     let mut inputs = HashMap::new();
     inputs.insert(ItemType::RawOre, 1);
 
-    let mut storage: EntitySet<_> = [Building::new_inventory(
+    let storage: EntitySet<_> = [Building::new_inventory(
         [1, -1],
         BuildingType::Storage,
         inputs.clone(),
@@ -53,8 +53,7 @@ fn test_pull_inputs() {
         [1, 3],
         [1, 1],
         &mut HashMap::new(),
-        storage.as_mut(),
-        &mut [],
+        &storage,
     );
 
     let mut expected = EntitySet::new();
@@ -87,7 +86,7 @@ impl HasInventory for MockInventory {
 
 #[test]
 fn test_push_outputs() {
-    let mut storage: EntitySet<_> = [Building::new([1, -1], BuildingType::Storage)]
+    let storage: EntitySet<_> = [Building::new([1, -1], BuildingType::Storage)]
         .into_iter()
         .collect();
 
@@ -102,7 +101,7 @@ fn test_push_outputs() {
         &MockTiles,
         &mut transports,
         &mut mock_inventory,
-        storage.iter_mut(),
+        &storage,
         &|_| true,
     );
 
@@ -210,11 +209,13 @@ fn test_pull_inputs2() {
     let mut inputs = HashMap::new();
     inputs.insert(ItemType::RawOre, 1);
 
-    let mut storage = [EntityEntry::new(Building::new_inventory(
+    let storage = [Building::new_inventory(
         [1, -1],
         BuildingType::Storage,
         inputs.clone(),
-    ))];
+    )]
+    .into_iter()
+    .collect();
 
     let mut transports = EntitySet::new();
 
@@ -226,8 +227,7 @@ fn test_pull_inputs2() {
         [1, 4],
         [1, 1],
         &mut HashMap::new(),
-        &mut storage,
-        &mut [],
+        &storage,
     );
 
     let mut expected = EntitySet::new();
@@ -253,7 +253,7 @@ fn test_pull_inputs2() {
 
 #[test]
 fn test_push_outputs2() {
-    let mut storage: EntitySet<_> = [Building::new([1, -1], BuildingType::Storage)]
+    let storage: EntitySet<_> = [Building::new([1, -1], BuildingType::Storage)]
         .into_iter()
         .collect();
 
@@ -270,7 +270,7 @@ fn test_push_outputs2() {
         &MockTiles2,
         &mut transports,
         &mut mock_inventory,
-        storage.iter_mut(),
+        &storage,
         &|_| true,
     );
 

--- a/game-logic/src/task.rs
+++ b/game-logic/src/task.rs
@@ -128,7 +128,7 @@ impl AsteroidColoniesGame {
         else {
             return Err(String::from("Needs a building at the destination"));
         };
-        for building in self.buildings.iter_mut() {
+        for mut building in self.buildings.iter_borrow_mut() {
             if 0 < *building.inventory.get(&ItemType::RawOre).unwrap_or(&0) {
                 building.task = Task::MoveItem {
                     t: MOVE_ITEM_TIME,
@@ -154,12 +154,16 @@ impl AsteroidColoniesGame {
     }
 
     pub(super) fn set_building_recipe(
-        &mut self,
+        &self,
         ix: i32,
         iy: i32,
         recipe: Option<&Recipe>,
     ) -> Result<bool, String> {
-        let Some(assembler) = self.buildings.iter_mut().find(|b| b.intersects([ix, iy])) else {
+        let Some(mut assembler) = self
+            .buildings
+            .iter_borrow_mut()
+            .find(|b| b.intersects([ix, iy]))
+        else {
             return Err(String::from("The building does not exist at the target"));
         };
         if !matches!(assembler.type_, BuildingType::Assembler) {

--- a/game-logic/src/task.rs
+++ b/game-logic/src/task.rs
@@ -109,7 +109,7 @@ impl AsteroidColoniesGame {
             return Err(String::from("Power grid is already installed in this tile"));
         }
         self.constructions
-            .push(Construction::new_power_grid([ix, iy]));
+            .insert(Construction::new_power_grid([ix, iy]));
         Ok(true)
     }
 

--- a/game-logic/src/task.rs
+++ b/game-logic/src/task.rs
@@ -8,7 +8,6 @@ use crate::{
     direction::Direction,
     game::CalculateBackImage,
     items::ItemType,
-    push_pull::send_item,
     transport::find_path,
     AsteroidColoniesGame, Pos, TileState, Tiles,
 };
@@ -112,22 +111,6 @@ impl AsteroidColoniesGame {
         self.constructions
             .push(Construction::new_power_grid([ix, iy]));
         Ok(true)
-    }
-
-    pub fn move_item(&mut self, from: Pos, to: Pos) -> Result<(), String> {
-        let mut src = self
-            .buildings
-            .iter_borrow_mut()
-            .find(|b| b.intersects(from))
-            .ok_or_else(|| "Moving an item needs a building at the source")?;
-        send_item(
-            &mut self.tiles,
-            &mut self.transports,
-            &mut *src,
-            to,
-            &self.buildings,
-            &|_| true,
-        )
     }
 
     pub(super) fn _is_clear(&self, ix: i32, iy: i32, size: [usize; 2]) -> bool {

--- a/game-logic/src/task.rs
+++ b/game-logic/src/task.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt::Display};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    building::{Building, BuildingType, Recipe},
+    building::{Building, BuildingType},
     construction::Construction,
     direction::Direction,
     game::CalculateBackImage,
@@ -151,26 +151,6 @@ impl AsteroidColoniesGame {
             }
         }
         true
-    }
-
-    pub(super) fn set_building_recipe(
-        &self,
-        ix: i32,
-        iy: i32,
-        recipe: Option<&Recipe>,
-    ) -> Result<bool, String> {
-        let Some(mut assembler) = self
-            .buildings
-            .iter_borrow_mut()
-            .find(|b| b.intersects([ix, iy]))
-        else {
-            return Err(String::from("The building does not exist at the target"));
-        };
-        if !matches!(assembler.type_, BuildingType::Assembler) {
-            return Err(String::from("The building is not an assembler"));
-        }
-        assembler.recipe = recipe.cloned();
-        Ok(true)
     }
 
     pub(super) fn process_task(

--- a/game-logic/src/transport.rs
+++ b/game-logic/src/transport.rs
@@ -74,9 +74,9 @@ impl AsteroidColoniesGame {
             .filter_map(|t| t.path.last().copied())
             .collect();
 
-        for (id, t) in self.transports.items_mut() {
+        for (id, mut t) in self.transports.items_mut() {
             if t.path.len() <= 1 {
-                let delivered = check_construction(id, t) || check_building(t);
+                let delivered = check_construction(id, &mut *t) || check_building(&mut *t);
                 if !delivered {
                     let tiles = &self.tiles;
                     let return_path = find_multipath(
@@ -93,6 +93,7 @@ impl AsteroidColoniesGame {
                         },
                     );
                     if let Some(return_path) = return_path {
+                        let t = &mut *t;
                         std::mem::swap(&mut t.src, &mut t.dest);
                         t.path = return_path;
                     }

--- a/game-logic/src/transport.rs
+++ b/game-logic/src/transport.rs
@@ -4,7 +4,10 @@ use std::{
     hash::Hash,
 };
 
-use crate::{direction::Direction, items::ItemType, AsteroidColoniesGame, Conveyor, Pos};
+use crate::{
+    direction::Direction, entity::EntityIterMutExt, items::ItemType, AsteroidColoniesGame,
+    Conveyor, Pos,
+};
 
 /// Transporting item
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -48,11 +51,11 @@ impl AsteroidColoniesGame {
         };
 
         let mut check_building = |t: &mut Transport| {
-            if let Some(building) = self
+            let building = self
                 .buildings
-                .iter_mut()
-                .find(|b| intersects(b.pos, b.type_.size(), t.dest))
-            {
+                .items_mut()
+                .find(|b| intersects(b.pos, b.type_.size(), t.dest));
+            if let Some(building) = building {
                 if building.inventory_size() + t.amount <= building.type_.capacity() {
                     *building.inventory.entry(t.item).or_default() += t.amount;
                     t.path.clear();

--- a/game-logic/src/transport.rs
+++ b/game-logic/src/transport.rs
@@ -106,14 +106,7 @@ impl AsteroidColoniesGame {
             }
         }
 
-        let removes: Vec<_> = self
-            .transports
-            .items()
-            .filter_map(|(i, v)| if v.path.is_empty() { Some(i) } else { None })
-            .collect();
-        for r in removes {
-            self.transports.remove(r);
-        }
+        self.transports.retain(|v| !v.path.is_empty());
     }
 }
 

--- a/game-logic/src/transport.rs
+++ b/game-logic/src/transport.rs
@@ -74,7 +74,7 @@ impl AsteroidColoniesGame {
             .filter_map(|t| t.path.last().copied())
             .collect();
 
-        for (id, mut t) in self.transports.items_mut() {
+        for (id, t) in self.transports.items_mut() {
             if t.path.len() <= 1 {
                 let delivered = check_construction(id, &mut *t) || check_building(&mut *t);
                 if !delivered {

--- a/game-logic/src/transport.rs
+++ b/game-logic/src/transport.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     direction::Direction,
-    entity::{EntityId, EntityIterMutExt, EntitySet},
+    entity::{EntityId, EntitySet},
     items::ItemType,
     AsteroidColoniesGame, Conveyor, Pos,
 };
@@ -56,7 +56,7 @@ impl AsteroidColoniesGame {
         let mut check_building = |t: &mut Transport| {
             let building = self
                 .buildings
-                .items_mut()
+                .iter_mut()
                 .find(|b| intersects(b.pos, b.type_.size(), t.dest));
             if let Some(building) = building {
                 if building.inventory_size() + t.amount <= building.type_.capacity() {

--- a/js/main.js
+++ b/js/main.js
@@ -109,6 +109,7 @@ heartbeatDiv.appendChild(heartbeatElem);
     game.render(ctx);
     let mousePos = null;
     let moving = false;
+    let movingItem = false;
     let buildingConveyor = null;
     let dragStart = null;
     let dragLast = null;
@@ -179,6 +180,19 @@ heartbeatDiv.appendChild(heartbeatElem);
             moving = false;
             return;
         }
+        if (movingItem) {
+            try {
+                const to = game.transform_coords(x, y);
+                const from = game.move_item(x, y);
+                requestWs("MoveItem", {from: [from[0], from[1]], to: [to[0], to[1]]});
+            }
+            catch (e) {
+                console.error(`move_item: ${e}`);
+            }
+            messageOverlayElem.style.display = "none";
+            movingItem = false;
+            return;
+        }
 
         if (buildingConveyor) {
             const elem = document.getElementById("conveyor");
@@ -201,9 +215,17 @@ heartbeatDiv.appendChild(heartbeatElem);
                 if (name === "move") {
                     if (game.start_move_building(x, y)) {
                         recipesElem.style.display = "none";
-                        messageOverlayElem.innerHTML = "Choose move destination";
+                        messageOverlayElem.innerHTML = "Choose move building destination";
                         messageOverlayElem.style.display = "block";
                         moving = true;
+                    }
+                }
+                else if (name === "moveItem") {
+                    if (game.start_move_item(x, y)) {
+                        recipesElem.style.display = "none";
+                        messageOverlayElem.innerHTML = "Choose move item destination";
+                        messageOverlayElem.style.display = "block";
+                        movingItem = true;
                     }
                 }
                 else if (name === "conveyor") {

--- a/server/src/websocket.rs
+++ b/server/src/websocket.rs
@@ -166,6 +166,10 @@ enum WsMessage {
         from: Pos,
         to: Pos,
     },
+    MoveItem {
+        from: Pos,
+        to: Pos,
+    },
     Build {
         pos: Pos,
         #[serde(rename = "type")]
@@ -232,7 +236,11 @@ impl SessionWs {
                 game.excavate(x, y).map_err(|e| anyhow::anyhow!("{e}"))?;
             }
             WsMessage::Move { from, to } => {
-                game.move_building(from[0], from[1], to[0], to[1])
+                game.move_building(from, to)
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+            }
+            WsMessage::MoveItem { from, to } => {
+                game.move_item(from, to)
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
             }
             WsMessage::Build { pos, ty } => match ty {

--- a/server/src/websocket.rs
+++ b/server/src/websocket.rs
@@ -97,7 +97,7 @@ impl Handler<Message> for SessionWs {
             Message::Text(txt) => ctx.text(txt),
             Message::Bin(bin) => ctx.binary(bin),
             Message::StateWithDiff => {
-                let game = self.data.game.read().unwrap();
+                let game = self.data.game.lock().unwrap();
                 match game.serialize_with_diffs(&self.chunks_digest) {
                     Ok(bytes) => ctx.binary(bytes),
                     Err(e) => ctx.text(format!("Error: {e}")),
@@ -225,7 +225,7 @@ impl StreamHandler<WsResult> for SessionWs {
 
 impl SessionWs {
     fn handle_message(&mut self, payload: WsMessage) -> anyhow::Result<()> {
-        let mut game = self.data.game.write().unwrap();
+        let mut game = self.data.game.lock().unwrap();
 
         match payload {
             WsMessage::Excavate { x, y } => {

--- a/wasm/src/info.rs
+++ b/wasm/src/info.rs
@@ -4,7 +4,7 @@ use crate::{render::TILE_SIZE, AsteroidColonies};
 use asteroid_colonies_logic::{
     building::{BuildingType, Recipe},
     construction::{BuildMenuItem, ConstructionType},
-    ItemType, Pos,
+    Inventory, ItemType, Pos,
 };
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
@@ -14,7 +14,7 @@ struct GetBuildingInfoResult {
     type_: BuildingType,
     recipe: Option<Recipe>,
     task: String,
-    inventory: HashMap<ItemType, usize>,
+    inventory: Inventory,
     crews: usize,
     max_crews: usize,
 }
@@ -23,7 +23,7 @@ struct GetBuildingInfoResult {
 struct GetConstructionInfoResult {
     type_: ConstructionType,
     recipe: BuildMenuItem,
-    ingredients: HashMap<ItemType, usize>,
+    ingredients: Inventory,
 }
 
 #[derive(Serialize)]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -120,7 +120,7 @@ impl AsteroidColonies {
 
     pub fn start_move_building(&mut self, x: f64, y: f64) -> bool {
         let pos = self.transform_pos(x, y);
-        let intersects = |b: &&Building| {
+        let intersects = |b: &Building| {
             let size = b.type_.size();
             b.pos[0] <= pos[0]
                 && pos[0] < size[0] as i32 + b.pos[0]
@@ -130,7 +130,7 @@ impl AsteroidColonies {
         if self
             .game
             .iter_building()
-            .find(intersects)
+            .find(|b| intersects(b))
             .is_some_and(|b| b.type_.is_mobile())
         {
             self.move_cursor = Some(pos);

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -8,8 +8,7 @@ use wasm_bindgen::prelude::*;
 use web_sys::js_sys;
 
 use asteroid_colonies_logic::{
-    building::{Building, BuildingType},
-    get_build_menu, AsteroidColoniesGame, Pos, HEIGHT, TILE_SIZE, WIDTH,
+    building::BuildingType, get_build_menu, AsteroidColoniesGame, Pos, HEIGHT, TILE_SIZE, WIDTH,
 };
 
 use crate::{assets::Assets, render::calculate_back_image};

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -158,9 +158,7 @@ impl AsteroidColonies {
         let dpos = self.transform_pos(dst_x, dst_y);
         if let Some(src) = self.move_cursor {
             self.move_cursor = None;
-            self.game
-                .move_building(src[0], src[1], dpos[0], dpos[1])
-                .map_err(JsValue::from)?;
+            self.game.move_building(src, dpos).map_err(JsValue::from)?;
             Ok(serde_wasm_bindgen::to_value(&src)?)
         } else {
             Err(JsValue::from("Select a building to move first"))


### PR DESCRIPTION
We want a stable id for each kind of objects and have a constant time to look up an object even if the number of entities scale. Entity (generation ids) is a common way to achieve this.

# Data structures

## EntitySet

In this PR, we define a struct `EntitySet` which abstract the concept of collection of entities.

```rust
struct EntitySet {
    v: Vec<EntityEntry<T>>,
}
```

## EntityEntry

Each entry's payload is wrapped in a `RefCell<Option<T>>` so that it can be occupied or vacant.
The `RefCell` allows simultaneous access to multiple entities of the same type.

```rust
pub struct EntityEntry<T> {
    pub gen: u32,
    pub payload: RefCell<Option<T>>,
}
```

### Why do we need `RefCell`?

When you process all entities (mutably) in a collection, you cannot access other elements in the same collection. Imagine a logic like pseudocode below. The call to `check_againt_other_entities` will fail to compile because `entities` collection is already borrowed mutably.

```rust
for entity in &mut entities {
     check_against_other_entities(&mut entities);
}
```

For the longest time, we used this slice trick to split the collection (in effect, only Vec can do this), and pass each halves of the collection as the "others".

```rust
for i in 0..entities.len() {
    let (first, rest) = entities.split_at_mut(i);
    let (this, last) = rest.split_first_mut().unwrap();
    check_against_other_entities(this, first, last);
}
```

But this method is ugly and won't work with more than 2 mutable references at the same time. This is getting more annoying since we can reference many random objects with `EntityId`, but we cannot utilize them. Imagine we had a `Transporter` entity that moves items from one entity to another. It needs to access 2 entities in the collection with random order.

We did some sophisticated tricks in FactorishWasm to implement multiple non-overlapping slices to split the Vec in `StructureDynIter` struct and allow simultaneous access to arbitrary number of elements, but it's so much work and it ends up requiring `Box<dyn Iterator>` to iterate, so it's not super effective. Simply using Rust standard library's `RefCell` should be more straightforward and could be more efficient.

At least that's what I thought, at first.

It turned out, even `RefCell` is not going to simplify a lot. See [entity.rs](https://github.com/msakuta/asteroid-colonies/blob/1c2bb5d772565d9b5e8525638e177db67ef66737/game-logic/src/entity.rs) for what I mean.


### Why `RefCell<Option<T>>`, not `Option<RefCell<T>>`?

Because whether the entry is occupied can change in a context with multiple mutable references.

It is best explained with `retain` method. `retain` method of `EntitySet` removes elements in the collection with which the given closure returns `false`. It's similar to `retain` method of `Vec`, but it keeps the buffer length and just assigns `None` to invalid entries. However, we would also want to use the other entities inside the closure. For this, provide `retain_borrow_mut` which takes a shared reference to `EntitySet` but uses internal mutability.

```rust
entities.retain_borrow_mut(|entity| {
     should_live(&entities)
});
```

In order to achieve this semantics, we need to wrap `Option` in a `RefCell`, because it controls mutability of `Option` itself.


## EntityId

Each entity can be addressed by EntityId, which is just this:

```rust
pub struct EntityId {
    id: u32,
    gen: u32,
}
```

See [generational-arena](https://docs.rs/generational-arena/latest/generational_arena/) crate for the idea.
We won't use generational-arena because it only provides [`get2_mut()`](https://docs.rs/generational-arena/latest/generational_arena/struct.Arena.html#method.get2_mut) but we don't want to be limited there.

## EntitySet methods

### Accessors

`EntitySet` has a bunch of iterator and accessor methods.

```rust
impl<T> EntitySet<T> {
    pub fn iter(&self) -> impl Iterator<Item = RefOption<T>>;
    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T>;
    pub fn iter_borrow_mut(&self) -> impl Iterator<Item = RefMutOption<T>>;
    pub fn items(&self) -> impl Iterator<Item = (EntityId, RefOption<T>)>;
    pub fn items_mut(&mut self) -> impl Iterator<Item = (EntityId, &mut T)>;
    pub fn items_borrow_mut(&self) -> impl Iterator<Item = (EntityId, RefMutOption<T>)>;
    pub fn get(&self, id: EntityId) -> Option<RefOption<T>>;
    pub fn get_mut(&mut self, id: EntityId) -> Option<&mut T>;
    pub fn get_mut_at(&mut self, idx: usize) -> Option<&mut T>;
    pub fn borrow_mut_at(&self, idx: usize) -> Option<RefMutOption<T>>;
}
```

Note the differences between `*_mut` and `*_borrow_mut` methods.
The former works on `&mut self`, so you have already a mutable access to the `EntitySet`. It doesn't need any refcount management, thus should be fast, but it can't access multiple entries at the same time.
The latter works on `&self`, which uses `RefCell` dynamic refcounting to enforce Rust reference rules. 

### Modifiers

```rust
impl<T> EntitySet<T> {
    pub fn insert(&mut self, val: T) -> EntityId;
    pub fn remove(&mut self, id: EntityId) -> Option<T>;
    pub fn retain(&mut self, mut f: impl FnMut(&mut T) -> bool);
    pub fn retain_borrow_mut(&self, mut f: impl FnMut(&mut T, EntityId) -> bool);
}
```

## `RefOption` and `RefMutOption`

There is another pair of reference types. They work similar to `Ref` and `RefMut` standard types to maintain the refcounter, but it is an abstraction of `Ref(Mut)` who always contains `Some`. It is necessary because `RefCell<Option<T>>` produces `Ref<Option<T>>` or `RefMut<Option<T>>` and they don't coerce to `Ref<T>` or `RefMut<T>` (which would be nice addition to the standard library by the way). Unfortunately there is no such method so that the user has to check if it contains `Some`.

Namely, the user has to write like this for every loop.

```rust
for entity in entities.iter() {
    let Some(entity) = entity else {
        continue;
    };
    do_somthing(&*entity);
}
```

This is too tedious and useless since we know that `iter()` method only returns `Some`. So we had to create our own type.

```rust
/// A wrapper around Ref<Option> that always has Some.
/// We need a Ref to release the refcounter, but we would never return
/// a Ref(None).
pub struct RefOption<'a, T>(Ref<'a, Option<T>>);

/// A wrapper around RefMut<Option> that always has Some.
/// We need a RefMut to release the refcounter, but we would never return
/// a RefMut(None).
pub struct RefMutOption<'a, T>(RefMut<'a, Option<T>>);
```

They implement `Deref` and `DerefMut`, so it can be used as if they were references to the underlying type, the same way as `Ref` or `RefMut`. The only difference is that they contain `Option<T>` and "knows" that the contents are always `Some`.

```rust
impl<'a, T> Deref for RefOption<'a, T> {
    type Target = T;
    fn deref(&self) -> &Self::Target {
        self.0.as_ref().unwrap()
    }
}

impl<'a, T> Deref for RefMutOption<'a, T> {
    type Target = T;
    fn deref(&self) -> &Self::Target {
        self.0.as_ref().unwrap()
    }
}

impl<'a, T> DerefMut for RefMutOption<'a, T> {
    fn deref_mut(&mut self) -> &mut Self::Target {
        self.0.as_mut().unwrap()
    }
}
```


# The `Mutex` vs `RwLock`

In the server, there was another unexpected drawback of using RefCell.

Now that we have RefCell as a part of `AsteroidColoniesGame`, it cannot be Sync (we would need Mutex to make it Sync).
It is a problem in the server where we would like to use `RwLock` to wrap `AsteroidColoniesGame`, because `RwLock` requires `Sync` bound for the internal type.

If it's unclear to you see the documentation of [`RwLock<T>`](https://doc.rust-lang.org/std/sync/struct.RwLock.html#impl-Sync-for-RwLock%3CT%3E). It becomes `Sync` only when `T` is `Sync`! On the other hand, [`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html#impl-Sync-for-Mutex%3CT%3E) is `Sync` no matter `T` is or not.

Why is that? Because read only access needs to guarantee that no internal mutability happens without thread synchronization.
It is actually protecting us from potential mutable access to `RefCell` in read only context, because `RefCell` does not provide thread safety.

The workaround is either to replace the `RwLock` with a `Mutex` or to replace all `RefCells` inside `AsteroidColoniesGame` with Mutexes.
Neither are great, but probably the former has less overhead, since we do not have so many readers at the same time.

In the end, we use the former workaround, i.e. use `Mutex` instead of `RwLock`.

```rust
struct ServerData {
    game: Mutex<AsteroidColoniesGame>,
    // ...
}
```  

It may have some overhead when there are many readers (sessions) that watches the same game instance, but I guess it's less than making the whole RefCells into Mutexes.

### Hope

What I would like is another level of mutability in the type system, i.e. synchronized reference. When we read contents of the data, we should use synchronized reference, so `RefCell`s can't use interior mutaility. When we are inside `RwLock`'s write guard, we know that no one can see the contents from other threads, so we should be able to use interior mutability. But I guess we need to wait for Rust 2.
