### PR TITLE
Update only changed buildings hash digest

### DIFF
--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -18,7 +18,7 @@ use crate::{
     AsteroidColoniesGame, Crew, Direction, TileState, Transport, Xor128,
 };
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Hash)]
 #[non_exhaustive]
 pub enum BuildingType {
     Power,
@@ -101,6 +101,18 @@ pub struct Recipe {
     pub time: f64,
 }
 
+impl std::hash::Hash for Recipe {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let mut inputs: Vec<_> = self.inputs.iter().collect();
+        inputs.sort_by_key(|(k, _)| *k);
+        inputs.hash(state);
+        let mut outputs: Vec<_> = self.outputs.iter().collect();
+        outputs.sort_by_key(|(k, _)| *k);
+        outputs.hash(state);
+        self.time.to_bits().hash(state);
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Building {
     pub pos: [i32; 2],
@@ -114,6 +126,20 @@ pub struct Building {
     pub recipe: Option<Recipe>,
     /// Some buildings have direction.
     pub direction: Option<Direction>,
+}
+
+impl std::hash::Hash for Building {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.pos.hash(state);
+        self.type_.hash(state);
+        self.task.hash(state);
+        let mut inventory: Vec<_> = self.inventory.iter().collect();
+        inventory.sort_by_key(|(k, _)| *k);
+        inventory.hash(state);
+        self.crews.hash(state);
+        self.recipe.hash(state);
+        self.direction.hash(state);
+    }
 }
 
 impl Building {

--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -101,18 +101,6 @@ pub struct Recipe {
     pub time: f64,
 }
 
-impl std::hash::Hash for Recipe {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        let mut inputs: Vec<_> = self.inputs.iter().collect();
-        inputs.sort_by_key(|(k, _)| *k);
-        inputs.hash(state);
-        let mut outputs: Vec<_> = self.outputs.iter().collect();
-        outputs.sort_by_key(|(k, _)| *k);
-        outputs.hash(state);
-        self.time.to_bits().hash(state);
-    }
-}
-
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Building {
     pub pos: [i32; 2],
@@ -126,20 +114,6 @@ pub struct Building {
     pub recipe: Option<Recipe>,
     /// Some buildings have direction.
     pub direction: Option<Direction>,
-}
-
-impl std::hash::Hash for Building {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.pos.hash(state);
-        self.type_.hash(state);
-        self.task.hash(state);
-        let mut inventory: Vec<_> = self.inventory.iter().collect();
-        inventory.sort_by_key(|(k, _)| *k);
-        inventory.hash(state);
-        self.crews.hash(state);
-        self.recipe.hash(state);
-        self.direction.hash(state);
-    }
 }
 
 impl Building {

--- a/game-logic/src/construction.rs
+++ b/game-logic/src/construction.rs
@@ -273,14 +273,13 @@ impl AsteroidColoniesGame {
                 let pos = construction.pos;
                 match construction.type_ {
                     ConstructionType::Building(ty) => {
-                        let b = self.buildings
-                            .iter_mut()
-                            .find(|c| c.payload.is_none());
+                        let b = self.buildings.iter_mut().find(|c| c.payload.is_none());
                         if let Some(b) = b {
                             b.gen += 1;
                             b.payload = Some(Building::new(pos, ty));
                         } else {
-                            self.buildings.push(EntityEntry::new(Building::new(pos, ty)));
+                            self.buildings
+                                .push(EntityEntry::new(Building::new(pos, ty)));
                         }
                     }
                     ConstructionType::PowerGrid => {

--- a/game-logic/src/entity.rs
+++ b/game-logic/src/entity.rs
@@ -7,6 +7,15 @@ pub struct EntityEntry<T> {
     pub payload: Option<T>,
 }
 
+impl<T> Default for EntityEntry<T> {
+    fn default() -> Self {
+        Self {
+            gen: 0,
+            payload: None,
+        }
+    }
+}
+
 impl<T> EntityEntry<T> {
     pub(crate) fn new(payload: T) -> Self {
         Self {

--- a/game-logic/src/items.rs
+++ b/game-logic/src/items.rs
@@ -4,7 +4,7 @@ use ::serde::{Deserialize, Serialize};
 
 use crate::{hash_map, Recipe};
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
 pub enum ItemType {
     /// Freshly dug soil from asteroid body. Hardly useful unless refined
     RawOre,

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -4,7 +4,7 @@ pub use crate::{
     conveyor::Conveyor,
     crew::Crew,
     direction::Direction,
-    game::{AsteroidColoniesGame, SerializeGame},
+    game::{AsteroidColoniesGame, DigestMessage, SerializeGame},
     items::ItemType,
     tile::{new_hasher, Chunk, ImageIdx, Position, Tile, TileState, Tiles, CHUNK_SIZE},
     transport::Transport,

--- a/game-logic/src/task.rs
+++ b/game-logic/src/task.rs
@@ -40,6 +40,34 @@ pub enum Task {
     // Smelt(usize),
 }
 
+impl std::hash::Hash for Task {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::None => {}
+            Self::Excavate(t, d) => {
+                t.to_bits().hash(state);
+                d.hash(state);
+            }
+            Self::Move(t, p) => {
+                t.to_bits().hash(state);
+                p.hash(state);
+            }
+            Self::MoveItem { t, item_type, dest } => {
+                t.to_bits().hash(state);
+                item_type.hash(state);
+                dest.hash(state);
+            }
+            Self::Assemble { t, max_t, outputs } => {
+                t.to_bits().hash(state);
+                max_t.to_bits().hash(state);
+                let mut outputs: Vec<_> = outputs.iter().collect();
+                outputs.sort_by_key(|(k, _)| *k);
+                outputs.hash(state);
+            }
+        }
+    }
+}
+
 impl Display for Task {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/js/main.js
+++ b/js/main.js
@@ -452,6 +452,8 @@ heartbeatDiv.appendChild(heartbeatElem);
         const chunksDigest = game.serialize_chunks_digest();
         // websocket.send(JSON.stringify({type: "ChunksDigest", payload: {chunks_digest: chunksDigest}}));
         websocket.send(chunksDigest);
+        const buildingsDigest = game.serialize_buildings_digest();
+        websocket.send(buildingsDigest);
     }
 })()
 

--- a/server/src/websocket.rs
+++ b/server/src/websocket.rs
@@ -13,7 +13,7 @@ use ::serde::{Deserialize, Serialize};
 use actix_web_actors::ws;
 use asteroid_colonies_logic::{
     construction::{Construction, ConstructionType},
-    Pos, Position,
+    DigestMessage, Pos, Position,
 };
 
 /// Open a WebSocket instance and give it to the client.
@@ -32,6 +32,7 @@ pub(crate) async fn websocket_index(
         session_id,
         addr: data.srv.clone(),
         chunks_digest: HashMap::new(),
+        buildings_digest: HashMap::new(),
     };
 
     // let srv = data.srv.clone();
@@ -51,6 +52,7 @@ struct SessionWs {
     pub session_id: SessionId,
     pub addr: Addr<ChatServer>,
     pub chunks_digest: HashMap<Position, u64>,
+    pub buildings_digest: HashMap<usize, u64>,
 }
 
 impl Actor for SessionWs {
@@ -98,7 +100,7 @@ impl Handler<Message> for SessionWs {
             Message::Bin(bin) => ctx.binary(bin),
             Message::StateWithDiff => {
                 let game = self.data.game.read().unwrap();
-                match game.serialize_with_diffs(&self.chunks_digest) {
+                match game.serialize_with_diffs(&self.chunks_digest, &self.buildings_digest) {
                     Ok(bytes) => ctx.binary(bytes),
                     Err(e) => ctx.text(format!("Error: {e}")),
                 }
@@ -213,11 +215,19 @@ impl StreamHandler<WsResult> for SessionWs {
                     ));
                 }
             }
-            Ok(ws::Message::Binary(bin)) => {
-                if let Ok(chunks_digest) = bincode::deserialize(&bin) {
+            Ok(ws::Message::Binary(bin)) => match bincode::deserialize::<DigestMessage>(&bin) {
+                Ok(DigestMessage::Chunks(chunks_digest)) => {
+                    println!("chunks_digest received via binary: {}", chunks_digest.len());
                     self.chunks_digest = chunks_digest;
                 }
-            }
+                Ok(DigestMessage::Buildings(buildings)) => {
+                    println!("buildings_digest received via binary: {:?}", buildings);
+                    self.buildings_digest = buildings;
+                }
+                Err(e) => {
+                    println!("DigestMessage receive error: {e}");
+                }
+            },
             _ => (),
         }
     }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -9,7 +9,7 @@ use web_sys::js_sys;
 
 use asteroid_colonies_logic::{
     building::{Building, BuildingType},
-    get_build_menu, AsteroidColoniesGame, Pos, HEIGHT, TILE_SIZE, WIDTH,
+    get_build_menu, new_hasher, AsteroidColoniesGame, Pos, HEIGHT, TILE_SIZE, WIDTH,
 };
 
 use crate::{assets::Assets, render::calculate_back_image};

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -253,6 +253,12 @@ impl AsteroidColonies {
             .serialize_chunks_digest()
             .map_err(|e| JsValue::from(e.to_string()))
     }
+
+    pub fn serialize_buildings_digest(&self) -> Result<Vec<u8>, JsValue> {
+        self.game
+            .serialize_buildings_digest()
+            .map_err(|e| JsValue::from(e.to_string()))
+    }
 }
 
 impl AsteroidColonies {


### PR DESCRIPTION
Similar idea to tile chunks in #2, but for building entities.

Before:

![image](https://github.com/msakuta/asteroid-colonies/assets/2798715/8a6a415c-3a96-41f8-8f51-1a5a7b52239a)

After:

![image](https://github.com/msakuta/asteroid-colonies/assets/2798715/a282b4b1-4125-4467-9313-e0585ef308cb)

Each upload tell the server about the objects hashes in the client. Then the server sends only changed objects to the client.

# Hashing objects

Hashing unknown object in memory is not as straightforward as serialized bytes. There are few pitfalls that probably using this idea of using hash to send diffs is not so worthwhile.

## `DefaultHasher`

Rust has `std::hash::DefaultHasher`, which is used by `HashMap`, but it is not suitable for us because they are deliberately not reproducible. We want reproducible hash that can be shared among the server and the client. For this, we use [FNV](https://github.com/servo/rust-fnv) hash.

## HashMap

Rust's HashMap has non-reproducible hash for security reasons, so hashing the whole HashMap yields different values every time. This will ruin the whole point to identify the same object by contents hash.

## usize

Rust's usize type is a pointer-sized integer, whose size changes among architectures. It is particularly problematic between x64 and Wasm. x64 uses 64 bits and Wasm uses 32 bits, so their hash will be different even if it has the same value.

The annoying type is `Vec`, which has usize as a field, but we cannot customize how it's hashed in `impl<T> Hash for Vec<T>`.
