### PR TITLE
Move item task improvement

### DIFF
--- a/game-logic/src/building.rs
+++ b/game-logic/src/building.rs
@@ -306,6 +306,7 @@ impl Building {
                             }
                             pos
                         }
+                        _ => continue,
                     };
                     if crews.iter().any(|crew| crew.target() == Some(*goal_pos)) {
                         continue;

--- a/game-logic/src/crew.rs
+++ b/game-logic/src/crew.rs
@@ -59,6 +59,7 @@ impl Crew {
                     item: None,
                 },
             ),
+            _ => return None,
         };
         let path = find_path(from_building.pos, target, |pos| {
             matches!(tiles[pos].state, TileState::Empty) || pos == target

--- a/game-logic/src/entity.rs
+++ b/game-logic/src/entity.rs
@@ -203,6 +203,16 @@ impl<T> EntitySet<T> {
             .and_then(|entry| entry.payload.get_mut().as_mut())
     }
 
+    pub fn borrow_mut(&self, id: EntityId) -> Option<RefMutOption<T>> {
+        self.v.get(id.id as usize).and_then(|entry| {
+            if id.gen == entry.gen {
+                RefMutOption::new(&entry.payload)
+            } else {
+                None
+            }
+        })
+    }
+
     pub fn borrow_mut_at(&self, idx: usize) -> Option<RefMutOption<T>> {
         self.v
             .get(idx)

--- a/game-logic/src/transport.rs
+++ b/game-logic/src/transport.rs
@@ -68,10 +68,16 @@ impl AsteroidColoniesGame {
             false
         };
 
-        let occupied: HashSet<_> = self
+        let occupied: HashMap<_, _> = self
             .transports
-            .iter()
-            .filter_map(|t| t.path.last().copied())
+            .items()
+            .filter_map(|(id, t)| {
+                if 2 <= t.path.len() {
+                    Some((t.path.get(t.path.len() - 2).copied()?, id))
+                } else {
+                    None
+                }
+            })
             .collect();
 
         for (id, t) in self.transports.items_mut() {
@@ -99,10 +105,10 @@ impl AsteroidColoniesGame {
                     }
                 }
             } else if t.path.len() <= 2
-                || t.path
-                    .get(t.path.len() - 2)
-                    .map(|pos| !occupied.contains(pos))
-                    .unwrap_or(true)
+                || t.path.get(t.path.len() - 2).map_or(true, |pos| {
+                    let predicted_id = occupied.get(pos);
+                    predicted_id == None || predicted_id == Some(&id)
+                })
             {
                 t.path.pop();
             }

--- a/js/graphics.js
+++ b/js/graphics.js
@@ -30,6 +30,7 @@ import furnaceItem from '../images/furnaceItem.png';
 import construction from '../images/construction.png';
 import deconstruction from '../images/deconstruction.png';
 import cleanup from '../images/cleanup.png';
+import moveItemIcon from '../images/moveItem.png';
 import excavate from '../images/excavate.png';
 import path from '../images/path.png';
 import heart from '../images/heart.png';
@@ -84,6 +85,7 @@ export async function loadAllIcons() {
         ["construction", construction],
         ["deconstruction", deconstruction],
         ["cleanup", cleanup],
+        ["move_item", moveItemIcon],
         ["excavate", excavate],
         ["path", path],
     ].map(async ([name, src]) => {

--- a/wasm/src/assets.rs
+++ b/wasm/src/assets.rs
@@ -32,6 +32,7 @@ pub(crate) struct Assets {
     pub img_construction: HtmlImageElement,
     pub img_deconstruction: HtmlImageElement,
     pub img_cleanup: HtmlImageElement,
+    pub img_move_item: HtmlImageElement,
 }
 
 impl Assets {
@@ -86,6 +87,7 @@ impl Assets {
             img_construction: load_texture("construction")?,
             img_deconstruction: load_texture("deconstruction")?,
             img_cleanup: load_texture("cleanup")?,
+            img_move_item: load_texture("move_item")?,
         })
     }
 

--- a/wasm/src/gl/assets.rs
+++ b/wasm/src/gl/assets.rs
@@ -84,6 +84,7 @@ pub(crate) struct Assets {
     pub tex_construction: WebGlTexture,
     pub tex_deconstruction: WebGlTexture,
     pub tex_cleanup: WebGlTexture,
+    pub tex_move_item: WebGlTexture,
     pub tex_excavate: WebGlTexture,
     pub tex_path: WebGlTexture,
 
@@ -211,6 +212,7 @@ impl Assets {
             tex_construction: load_texture_local("construction")?,
             tex_deconstruction: load_texture_local("deconstruction")?,
             tex_cleanup: load_texture_local("cleanup")?,
+            tex_move_item: load_texture_local("move_item")?,
             tex_excavate: load_texture_local("excavate")?,
             tex_path: load_texture_local("path")?,
 

--- a/wasm/src/gl/render_gl/building.rs
+++ b/wasm/src/gl/render_gl/building.rs
@@ -1,4 +1,9 @@
-use super::{super::utils::Flatten, enable_buffer, lerp, path::render_path, RenderContext};
+use super::{
+    super::utils::Flatten,
+    enable_buffer, lerp,
+    path::{prepare_render_path, render_path},
+    RenderContext,
+};
 use crate::{
     gl::shader_bundle::ShaderBundle,
     render::{BAR_HEIGHT, BAR_MARGIN, BAR_WIDTH, TILE_SIZE},
@@ -173,7 +178,11 @@ impl AsteroidColonies {
             ) {
                 render_main(&building);
             }
+        }
 
+        prepare_render_path(gl, ctx);
+
+        for building in self.game.iter_building() {
             if let BuildingTask::Move(_, path) = &building.task {
                 render_path(gl, ctx, path, &[1., 0.5, 0.0, 1.]);
             }

--- a/wasm/src/gl/render_gl/global_tasks.rs
+++ b/wasm/src/gl/render_gl/global_tasks.rs
@@ -22,6 +22,11 @@ impl AsteroidColonies {
                 GlobalTask::Cleanup(pos) => {
                     render_icon(gl, ctx, *pos, &assets.tex_cleanup);
                 }
+                GlobalTask::MoveItem { src, .. } => {
+                    if let Some(bldg) = self.game.get_building(*src) {
+                        render_icon(gl, ctx, bldg.pos, &assets.tex_move_item);
+                    }
+                }
             }
         }
     }

--- a/wasm/src/gl/render_gl/path.rs
+++ b/wasm/src/gl/render_gl/path.rs
@@ -11,7 +11,7 @@ use cgmath::{vec2, InnerSpace, Matrix3, Matrix4, SquareMatrix, Vector2, Vector3}
 const PATH_WIDTH: f32 = 0.1;
 const TEX_SCROLL_SCALE: f32 = 0.5;
 
-pub(super) fn render_path(gl: &GL, ctx: &RenderContext, path: &[[i32; 2]], color: &[f32; 4]) {
+pub(super) fn prepare_render_path(gl: &GL, ctx: &RenderContext) {
     let shader = &ctx.assets.vertex_textured_shader;
     gl.use_program(Some(&shader.program));
     gl.bind_texture(GL::TEXTURE_2D, Some(&ctx.assets.tex_path));
@@ -21,6 +21,10 @@ pub(super) fn render_path(gl: &GL, ctx: &RenderContext, path: &[[i32; 2]], color
         false,
         Matrix3::identity().flatten(),
     );
+}
+
+pub(super) fn render_path(gl: &GL, ctx: &RenderContext, path: &[[i32; 2]], color: &[f32; 4]) {
+    let shader = &ctx.assets.vertex_textured_shader;
 
     let mut vertices = Vec::with_capacity(path.len() * 8);
     let mut add_vertex = |pos: Vector2<f32>, normal: Vector2<f32>, t: f32| {

--- a/wasm/src/gl/render_gl/transports.rs
+++ b/wasm/src/gl/render_gl/transports.rs
@@ -1,4 +1,9 @@
-use super::{super::utils::Flatten, lerp, path::render_path, RenderContext};
+use super::{
+    super::utils::Flatten,
+    lerp,
+    path::{prepare_render_path, render_path},
+    RenderContext,
+};
 use crate::{gl::utils::enable_buffer, AsteroidColonies};
 
 use ::asteroid_colonies_logic::{Transport, TILE_SIZE};
@@ -54,9 +59,14 @@ impl AsteroidColonies {
             gl.draw_arrays(GL::TRIANGLE_FAN, 0, 4);
         };
 
+        prepare_render_path(gl, ctx);
+
         for t in self.game.iter_transport() {
             render_path(gl, ctx, &t.path, &[1., 1., 0., 1.]);
-            gl.use_program(Some(&shader.program));
+        }
+
+        gl.use_program(Some(&shader.program));
+        for t in self.game.iter_transport() {
             enable_buffer(gl, &assets.screen_buffer, 2, shader.vertex_position);
             render_transport(&t);
         }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -197,9 +197,7 @@ impl AsteroidColonies {
             .move_item_cursor
             .ok_or_else(|| JsValue::from("Select a building to move items from first"))?;
         self.move_item_cursor = None;
-        self.game
-            .move_item(src, dpos, item)
-            .map_err(JsValue::from)?;
+        self.game.move_item(src, dpos, item)?;
         Ok(serde_wasm_bindgen::to_value(&src)?)
     }
 

--- a/wasm/src/render.rs
+++ b/wasm/src/render.rs
@@ -378,6 +378,14 @@ impl AsteroidColonies {
                     context.draw_image_with_html_image_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
                         &self.assets.img_cleanup, 0., 0., 32., 32., x, y, 32., 32.)?;
                 }
+                GlobalTask::MoveItem { src, .. } => {
+                    if let Some(bldg) = self.game.get_building(*src) {
+                        let x = bldg.pos[0] as f64 * TILE_SIZE + offset[0];
+                        let y = bldg.pos[1] as f64 * TILE_SIZE + offset[1];
+                        context.draw_image_with_html_image_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
+                            &self.assets.img_move_item, 0., 0., 32., 32., x, y, 32., 32.)?;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
We had a command MoveItem in the menu

![image](https://github.com/msakuta/asteroid-colonies/assets/2798715/9db479f7-0cea-4325-bad1-2deb9dabde27)

but this was not a great tool, because it can magically transport all the items of the same type with single transport. It is unrealistic given that other automated products can only pass 1 unit of item per transport.

We would like to send a series of items in separate transports like below. It will occupy the conveyor and it constrains the throughput, which is more realistic.

We would like something like below, when the player puts the command to send items.

![image](https://github.com/msakuta/asteroid-colonies/assets/2798715/b9c6f754-8f11-4df8-92cc-1962e60dc987)

It sounds simple, but it had few things to do:

* Define a new GlobalTask which is called MoveItem
* If the building is a target of a MoveItem task, the building can send the contents through a conveyor, if any connects the source and the destination.
* If the building is unreachable through conveyor, we try sending crews to deliver the item, assuming the building is a CrewCabin and it has a crew in it.
* If it fails, we try finding a CrewCabin and a crew that can pick up and deliver.
* If all above fail, we give up.
